### PR TITLE
Section Pattern Matching Language inspired by RegExp

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The `types` property is an array of string values that describes the type of the
 
 - `has-<type>`: for each type of content that occurs at least once in the section, e.g. has-heading
 - `is-<type>-only`: for sections that only have content of a single type, e.g. is-image-only
-- `is-<type-1>-<type-2>-<type3>`, `is-<type-1>-<type-2>`, and `is-<type-1>` for the top 3 most frequent types of children in the section. For instance a gallery with a heading and description would be `is-image-paragraph-heading`.
+- `is-<type-1>-<type-2>-<type3>`, `is-<type-1>-<type-2>`, and `is-<type-1>` for the top 3 most frequent types of children in the section. For instance a gallery with a heading and description would be `is-image-paragraph-heading`. You can infer additional types using [`utils.types`](#infer-content-types-with-utilstypes).
 
 Each section has additional content-derived metadata properties, in particular:
 
@@ -195,3 +195,30 @@ Alternatively, steps can attempt to handle the `error` object, for instance by g
 The only known property in `error` is
 
 - `message`: the error message
+
+## Utilities
+
+### Infer Content Types with `utils.types`
+
+In addition to the automatically inferred content types for each section, `utils.types` provides a `TypeMatcher` utility class that allows matching section content against a simple expression language and thus enrich the `section[].types` values.
+
+
+```javascript
+const TypeMatcher = require('@adobe/hypermedia-pipeline').utils.types;
+
+const matcher = new TypeMatcher(content.sections);
+matcher.match('^heading', 'starts-with-heading');
+content.sections = matcher.process();
+```
+
+In the example above, all sections that have a `heading` as the first child will get the value `starts-with-heading` appended to the `types` array. `^heading` is an example of the content expression language, which allows matching content against a simple regular expression-like syntax.
+
+##### Content Expression Language
+
+* `^heading` – the first element is a `heading`
+* `paragraph$` – the last element is a `paragraph`
+* `heading image+` – a `heading` followed by one or more `image`s
+* `heading? image` – an optional `heading` followed by one `image`
+* `heading paragraph* image` – a `heading` followed by any number of `paragraph`s (also no paragraphs at all), followed by an `image`
+* `(paragraph|list)` – a `paragraph` or a `list`
+* `^heading (image paragraph)+$` – one `heading`, followed by pairs of `image` and `paragraph`, but at least one

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -10,12 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-const defaults = require('./src/defaults/default.js');
-const Pipeline = require('./src/pipeline.js');
-const utils = require('./src/utils');
+const vdom = require('./mdast-to-vdom');
 
 module.exports = {
-  Pipeline,
-  defaults,
-  utils,
+  vdom,
 };

--- a/src/utils/match-section-types.js
+++ b/src/utils/match-section-types.js
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-const types = require('./match-section-types');
-
-module.exports = {
-  types,
-};
+class TypeMatcher {
+  constructor(section) {
+    const children = Array.isArray(section) ? section : section.children;
+  }
+}

--- a/src/utils/match-section-types.js
+++ b/src/utils/match-section-types.js
@@ -22,9 +22,10 @@ class TypeMatcher {
    * @param {(Node|Node[])} section the parent node or list of child nodes to evaluate
    * the registered content expressions against.
    */
-  constructor(section) {
-    const children = Array.isArray(section) ? section : section.children;
-    this._section = section.children ? section : null;
+  constructor(section = []) {
+    const mysection = section || [];
+    const children = Array.isArray(mysection) ? mysection : mysection.children;
+    this._section = mysection.children ? mysection : null;
     this._matchers = [];
     // get the type for each node, skip everything that's not a node or
     // doesn't have a type

--- a/src/utils/match-section-types.js
+++ b/src/utils/match-section-types.js
@@ -90,21 +90,21 @@ class TypeMatcher {
    * @returns {(Node|Node[])} the processed sections
    */
   process() {
-    const mapped = this._sections.map(section => {
+    const mapped = this._sections.map((section) => {
       // get the type for each node, skip everything that's not a node or
       // doesn't have a type
-      const childtypes = section.children ? 
-        section.children.map(node => node.type).filter(type => !!type) :
-        [];
+      const childtypes = section.children
+        ? section.children.map(node => node.type).filter(type => !!type)
+        : [];
       const matchedtypes = this.matches(childtypes);
       const oldtypes = section.types && Array.isArray(section.types) ? section.types : [];
 
-      return {
+      return Object.assign({
         types: [...matchedtypes, ...oldtypes],
-        ...section
-      }
+
+      }, section);
     });
-    if (mapped.length===1) {
+    if (mapped.length === 1) {
       return mapped[0];
     }
     return mapped;

--- a/src/utils/pattern-compiler.js
+++ b/src/utils/pattern-compiler.js
@@ -13,7 +13,7 @@
 /**
  * Turns a content-expression like "heading? (paragraph|image)+" into
  * a proper regular expression.
- * @param {string} pattern 
+ * @param {string} pattern
  * @returns {RegExp} a regular expression that matches strings following
  * the high-level pattern.
  */
@@ -29,7 +29,7 @@ function compile(pattern) {
 /**
  * Determines if the provided list of child nodes matches the
  * type expression
- * @param {string[]} list a list of node types 
+ * @param {string[]} list a list of node types
  * @param {string} pattern a content-expression like "heading? (paragraph|image)+"
  * @returns true if the list matches the pattern
  */

--- a/src/utils/pattern-compiler.js
+++ b/src/utils/pattern-compiler.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+function compile(pattern) {
+  // console.log(pattern);
+  const expression = new RegExp(pattern
+    .replace(/(\w+)/g, '($1·)') // always match whole words
+    .replace(/ /g, '') // remove spaces
+    .toString());
+  // console.log(expression);
+  return expression;
+}
+
+function match(list, pattern) {
+  return compile(pattern).test(list.join('·'));
+}
+
+module.exports = {
+  compile,
+  match,
+};

--- a/src/utils/pattern-compiler.js
+++ b/src/utils/pattern-compiler.js
@@ -13,7 +13,7 @@
 /**
  * Turns a content-expression like "heading? (paragraph|image)+" into
  * a proper regular expression.
- * @param {string} pattern
+ * @param {string} pattern the content expression
  * @returns {RegExp} a regular expression that matches strings following
  * the high-level pattern.
  */

--- a/src/utils/pattern-compiler.js
+++ b/src/utils/pattern-compiler.js
@@ -11,17 +11,20 @@
  */
 
 function compile(pattern) {
-  // console.log(pattern);
   const expression = new RegExp(pattern
     .replace(/(\w+)/g, '($1·)') // always match whole words
     .replace(/ /g, '') // remove spaces
     .toString());
-  // console.log(expression);
+  // console.log('=> ' + expression);
   return expression;
 }
 
 function match(list, pattern) {
-  return compile(pattern).test(list.join('·'));
+  const str = `${list.join('·')}·`;
+  // console.log('-> ' + str);
+  const matches = !!compile(pattern).test(str);
+  // console.log(matches);
+  return matches;
 }
 
 module.exports = {

--- a/src/utils/pattern-compiler.js
+++ b/src/utils/pattern-compiler.js
@@ -10,6 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
+/**
+ * Turns a content-expression like "heading? (paragraph|image)+" into
+ * a proper regular expression.
+ * @param {string} pattern 
+ * @returns {RegExp} a regular expression that matches strings following
+ * the high-level pattern.
+ */
 function compile(pattern) {
   const expression = new RegExp(pattern
     .replace(/(\w+)/g, '($1·)') // always match whole words
@@ -19,6 +26,13 @@ function compile(pattern) {
   return expression;
 }
 
+/**
+ * Determines if the provided list of child nodes matches the
+ * type expression
+ * @param {string[]} list a list of node types 
+ * @param {string} pattern a content-expression like "heading? (paragraph|image)+"
+ * @returns true if the list matches the pattern
+ */
 function match(list, pattern) {
   const str = `${list.join('·')}·`;
   // console.log('-> ' + str);

--- a/test/testPatternCompiler.js
+++ b/test/testPatternCompiler.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+
+const assert = require('assert');
+const pattern = require('../src/utils/pattern-compiler');
+
+describe('Test compiled patterns', () => {
+  it('Basic pattern matches', () => {
+    assert.ok(pattern.match(['heading', 'paragraph', 'paragraph'], 'heading? paragraph+'));
+    assert.ok(!pattern.match(['heading', 'paragraph'], 'heading? paragraph+'));
+  });
+
+  it('Or expressions work', () => {
+    assert.ok(pattern.match(['heading', 'image', 'paragraph'], '^heading? (paragraph|image)+'));
+    assert.ok(pattern.match(['heading', 'paragraph', 'image'], 'heading? (paragraph|image)+'));
+  });
+});

--- a/test/testPatternCompiler.js
+++ b/test/testPatternCompiler.js
@@ -17,11 +17,37 @@ const pattern = require('../src/utils/pattern-compiler');
 describe('Test compiled patterns', () => {
   it('Basic pattern matches', () => {
     assert.ok(pattern.match(['heading', 'paragraph', 'paragraph'], 'heading? paragraph+'));
-    assert.ok(!pattern.match(['heading', 'paragraph'], 'heading? paragraph+'));
+    assert.ok(!pattern.match(['heading', 'paragraph'], 'heading? paragraph paragraph+'));
   });
 
   it('Or expressions work', () => {
     assert.ok(pattern.match(['heading', 'image', 'paragraph'], '^heading? (paragraph|image)+'));
     assert.ok(pattern.match(['heading', 'paragraph', 'image'], 'heading? (paragraph|image)+'));
+  });
+
+  it('Matches a gallery', () => {
+    const gallery = '^heading? image image image+$';
+    assert.ok(pattern.match(
+      ['heading', 'image', 'image', 'image', 'image'], gallery,
+    ));
+    assert.ok(pattern.match(
+      ['heading', 'image', 'image', 'image', 'image', 'image'], gallery,
+    ));
+    assert.ok(pattern.match(
+      ['image', 'image', 'image', 'image'], gallery,
+    ));
+  });
+
+  it('Matches a section with text or lists', () => {
+    const textlist = '^heading? (paragraph|list)+$';
+    assert.ok(pattern.match(
+      ['heading', 'list', 'list', 'list', 'list'], textlist,
+    ));
+    assert.ok(pattern.match(
+      ['heading', 'paragraph', 'paragraph', 'list', 'paragraph', 'paragraph'], textlist,
+    ));
+    assert.ok(pattern.match(
+      ['paragraph', 'list', 'paragraph', 'list'], textlist,
+    ));
   });
 });

--- a/test/testTypeMatcher.js
+++ b/test/testTypeMatcher.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+const fs = require('fs-extra');
+const path = require('path');
+const assert = require('assert');
+const TypeMatcher = require('../src/utils/match-section-types');
+
+
+describe('Test Type Matcher Util', () => {
+  const sections = fs.readJSONSync(path.resolve(__dirname, 'fixtures', 'sections.json'));
+
+  it('TypeMatcher works with empty input', () => {
+    assert.deepEqual(new TypeMatcher(null).process(), []);
+    assert.deepEqual(new TypeMatcher().process(), []);
+    assert.deepEqual(new TypeMatcher([]).process(), []);
+  });
+
+  it('TypeMatcher returns empty array if no matchers are registered', () => {
+    assert.deepEqual(new TypeMatcher(sections[0])
+      .process(), []);
+  });
+
+  it('TypeMatcher matches simple expressions', () => {
+    assert.deepEqual(new TypeMatcher(sections[0])
+      .match('heading', 'has-heading')
+      .process(), ['has-heading']);
+  });
+
+  it('TypeMatcher matches multiple expressions', () => {
+    assert.deepEqual(new TypeMatcher(sections[0])
+      .match('heading', 'has-heading')
+      .match('paragraph', 'has-paragraph')
+      .match('impossible', 'has-impossible')
+      .process(), ['has-heading', 'has-paragraph']);
+  });
+});

--- a/test/testTypeMatcher.js
+++ b/test/testTypeMatcher.js
@@ -27,13 +27,13 @@ describe('Test Type Matcher Util', () => {
 
   it('TypeMatcher returns empty array if no matchers are registered', () => {
     assert.deepEqual(new TypeMatcher(sections[0])
-      .process(), []);
+      .process().types, []);
   });
 
   it('TypeMatcher matches simple expressions', () => {
     assert.deepEqual(new TypeMatcher(sections[0])
       .match('heading', 'has-heading')
-      .process(), ['has-heading']);
+      .process().types, ['has-heading']);
   });
 
   it('TypeMatcher matches multiple expressions', () => {
@@ -41,7 +41,7 @@ describe('Test Type Matcher Util', () => {
       .match('heading', 'has-heading')
       .match('paragraph', 'has-paragraph')
       .match('impossible', 'has-impossible')
-      .process(), ['has-heading', 'has-paragraph']);
+      .process().types, ['has-heading', 'has-paragraph']);
   });
 
   it('TypeMatcher can match with functions', () => {
@@ -49,6 +49,19 @@ describe('Test Type Matcher Util', () => {
       .match('heading', 'has-heading')
       .match('paragraph', 'has-paragraph')
       .match(types => types.length >= 3, 'long')
-      .process(), ['has-heading', 'has-paragraph', 'long']);
+      .process().types, ['has-heading', 'has-paragraph', 'long']);
+  });
+
+  it('TypeMatcher can match with functions', () => {
+    const matchedsections = new TypeMatcher(sections)
+    .match('heading', 'has-heading')
+    .match('paragraph', 'has-paragraph')
+    .match(types => types.length >= 3, 'long')
+    .process();
+    assert.equal(matchedsections.length, 4);
+    assert.ok(matchedsections[0].types);
+    assert.ok(matchedsections[1].types);
+    assert.deepEqual(matchedsections[2].types, ['has-heading', 'has-paragraph', 'long']);
+    assert.deepEqual(matchedsections[3].types, ['has-heading', 'has-paragraph', 'long']);
   });
 });

--- a/test/testTypeMatcher.js
+++ b/test/testTypeMatcher.js
@@ -43,4 +43,12 @@ describe('Test Type Matcher Util', () => {
       .match('impossible', 'has-impossible')
       .process(), ['has-heading', 'has-paragraph']);
   });
+
+  it('TypeMatcher can match with functions', () => {
+    assert.deepEqual(new TypeMatcher(sections[0])
+      .match('heading', 'has-heading')
+      .match('paragraph', 'has-paragraph')
+      .match(types => types.length >= 3, 'long')
+      .process(), ['has-heading', 'has-paragraph', 'long']);
+  });
 });

--- a/test/testTypeMatcher.js
+++ b/test/testTypeMatcher.js
@@ -54,10 +54,10 @@ describe('Test Type Matcher Util', () => {
 
   it('TypeMatcher can match with functions', () => {
     const matchedsections = new TypeMatcher(sections)
-    .match('heading', 'has-heading')
-    .match('paragraph', 'has-paragraph')
-    .match(types => types.length >= 3, 'long')
-    .process();
+      .match('heading', 'has-heading')
+      .match('paragraph', 'has-paragraph')
+      .match(types => types.length >= 3, 'long')
+      .process();
     assert.equal(matchedsections.length, 4);
     assert.ok(matchedsections[0].types);
     assert.ok(matchedsections[1].types);


### PR DESCRIPTION
This is a WIP implementation of #50 that does not require developers to build state machines from hand or to learn a new API to match sequences of elements, because it is simply using Regular expressions.

For instance to identify a "Gallery", i.e. a section that has at least three images, and maybe a heading, use `^heading? image image image+$`.

To identify a section that has only lists or paragraphs (and maybe a heading in the beginning), use `^heading? (paragraph|list)+$`.

It is intended to work with #47 and uses the new `utils` namespace from #53, so that it can be called from `pre.js`

Still outstanding:
- [x] merge #47 
- [x] provide `ContentMatcher` class with `match(expression, typename)` and `process` methods.
- [x] allow `match` to take in expressions or matching functions
- [x] let `process` set the matching `types` array
- [x] update README