### PR TITLE
Surrogate keys

### DIFF
--- a/src/defaults/html.pipe.js
+++ b/src/defaults/html.pipe.js
@@ -22,6 +22,7 @@ const type = require('../html/set-content-type.js');
 const smartypants = require('../html/smartypants');
 const sections = require('../html/split-sections');
 const debug = require('../html/output-debug.js');
+const key = require('../html/set-surrogate-key');
 
 /* eslint no-param-reassign: off */
 
@@ -41,6 +42,7 @@ const htmlpipe = (cont, payload, action) => {
     .pre(emit)
     .once(cont)
     .post(type)
+    .post(key)
     .post(debug)
     .post(adaptOWResponse);
 

--- a/src/html/fetch-markdown.js
+++ b/src/html/fetch-markdown.js
@@ -37,7 +37,8 @@ function uri(root, owner, repo, ref, path) {
  * the body of the Markdown document
  * @param {object} context pipeline context/payload
  * @param {object} context.content existing content (should be empty)
- * @param {string[]} context.content.sources list of URLs that have been retrieved for this piece of content
+ * @param {string[]} context.content.sources list of URLs that have been retrieved for
+ * this piece of content
  * @param {string} context.error pre-existing error message
  * @param {object} action the pipeline action
  * @param {object} action.request the HTTP request made to the runtime function
@@ -48,7 +49,7 @@ function uri(root, owner, repo, ref, path) {
  * @param {string} action.request.params.path path of the file to be requested
  */
 function fetch(
-  { error, content: { sources = []} = {}},
+  { error, content: { sources = [] } = {} },
   {
     secrets = {},
     request,

--- a/src/html/fetch-markdown.js
+++ b/src/html/fetch-markdown.js
@@ -32,8 +32,23 @@ function uri(root, owner, repo, ref, path) {
   });
 }
 
+/**
+ * Fetches the Markdown specified in the action and returns
+ * the body of the Markdown document
+ * @param {object} context pipeline context/payload
+ * @param {object} context.content existing content (should be empty)
+ * @param {string[]} context.content.sources list of URLs that have been retrieved for this piece of content
+ * @param {string} context.error pre-existing error message
+ * @param {object} action the pipeline action
+ * @param {object} action.request the HTTP request made to the runtime function
+ * @param {object} action.request.params URL params of the runtime function
+ * @param {string} action.request.params.owner organization or username owning the repository
+ * @param {string} action.request.params.repo name of the repository
+ * @param {string} action.request.params.ref branch, tag or commit identifier
+ * @param {string} action.request.params.path path of the file to be requested
+ */
 function fetch(
-  { error },
+  { error, content: { sources = []} = {}},
   {
     secrets = {},
     request,
@@ -76,7 +91,7 @@ function fetch(
   };
   logger.debug(`fetching Markdown from ${options.uri}`);
   return client(options)
-    .then(resp => ({ content: { body: resp } }))
+    .then(resp => ({ content: { body: resp, sources: [...sources, options.uri] } }))
     .catch(err => bail(logger, `Could not fetch Markdown from ${options.uri}`, err));
 }
 module.exports = fetch;

--- a/src/html/set-surrogate-key.js
+++ b/src/html/set-surrogate-key.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const crypto = require('crypto');
+
+function key({ content, response }, { logger }) {
+  // somebody already set a surrogate key
+  if (!(response && response.headers && response.headers['Surrogate-Key']) && (content && content.sources && Array.isArray(content.sources))) {
+    logger.debug('Setting Surrogate-Key header');
+    return {
+      response: {
+        headers: {
+          'Surrogate-Key': content.sources.map((uri) => {
+            const hash = crypto.createHash('sha256');
+            hash.update(uri);
+            return hash.digest('hex');
+          }).join(' '),
+        },
+      },
+    };
+  }
+  logger.debug('Keeping existing Surrogate-Key header');
+  return {};
+}
+module.exports = key;

--- a/test/testHTML.js
+++ b/test/testHTML.js
@@ -88,6 +88,7 @@ describe('Testing HTML Pipeline', () => {
         assert.equal('Medium', content.meta.template);
         assert.equal('Project Helix', content.intro);
         assert.equal('Bill, Welcome to the future', content.title);
+        assert.deepEqual(content.sources, ['https://raw.githubusercontent.com/trieloff/soupdemo/master/hello.md']);
         // and return a different status code
         return { response: { status: 201, body: content.html } };
       },

--- a/test/testHTML.js
+++ b/test/testHTML.js
@@ -103,8 +103,37 @@ describe('Testing HTML Pipeline', () => {
     result.then((res) => {
       assert.equal(201, res.statusCode);
       assert.equal('text/html', res.headers['Content-Type']);
+      assert.equal(res.headers['Surrogate-Key'], '87f5a156e8e5fa7e8a00dc18581e7b7e192f8dfcf30027926b00009ddcd674ad');
       assert.equal('<', res.body[0]);
       assert.ok(res.body.match(/srcset/));
+      done();
+    });
+  });
+
+  it('html.pipe keeps existing headers', (done) => {
+    const result = pipe(
+      ({ content }) => ({
+        response: {
+          status: 201,
+          body: content.html,
+          headers: {
+            'Content-Type': 'text/plain',
+            'Surrogate-Key': 'foobar',
+          },
+        },
+      }),
+      {},
+      {
+        request: { params },
+        secrets,
+        logger,
+      },
+    );
+
+    result.then((res) => {
+      assert.equal(201, res.statusCode);
+      assert.equal('text/plain', res.headers['Content-Type']);
+      assert.equal(res.headers['Surrogate-Key'], 'foobar');
       done();
     });
   });


### PR DESCRIPTION
Fixes #23 

Each URL that is fetched individually to render the content should be listed in `content.sources`.

Each URL in `content.sources` will then be sha256 hashed and added to `Surrogate-Keys`.

If you want to write a selective cache invalidator (👋 @tripodsan), go over each file in the commit event, and go over each name of the commit (e.g. branch or tag names when pushed), calculate the `raw.githubusercontent.com` URL and get the hash.