### PR TITLE
Tap Pipeline & Dump Context for Debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 pipeline.log
 logs/pipeline.log
 .nyc_output
+debug

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules/
 pipeline.log
 logs/pipeline.log
 .nyc_output
-debug
+logs/debug

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ In the example above, all sections that have a `heading` as the first child will
 
 When run in non-production, i.e. outside an OpenWhisk action, for example in `hlx up`, Pipeline Dumping is enabled. Pipeline Dumping allows developers to easily inspect the `Context` object of each step of the pipeline and can be used to debug pipeline functions and to generate realistic test cases.
 
-Each stage of the pipeline processing will create a file like `$PWD/debug/context_dump_34161BE5KuR0nuFDp/context-2018-9-2-14-18-5.635-step-2.json` inside the `debug` directory. These dumps will be removed when the `node` process ends, so that after stopping `hlx up` the `debug` directory will be clean again. The `-step-n` in the filename indicates the step in the pipeline that has been logged.
+Each stage of the pipeline processing will create a file like `$PWD/debug/context_dump_34161BE5KuR0nuFDp/context-20180902-1418-05.0635-step-2.json` inside the `debug` directory. These dumps will be removed when the `node` process ends, so that after stopping `hlx up` the `debug` directory will be clean again. The `-step-n` in the filename indicates the step in the pipeline that has been logged.
 
 A simple example might look like this:
 

--- a/README.md
+++ b/README.md
@@ -390,3 +390,215 @@ In the example above, all sections that have a `heading` as the first child will
 * `heading paragraph* image` – a `heading` followed by any number of `paragraph`s (also no paragraphs at all), followed by an `image`
 * `(paragraph|list)` – a `paragraph` or a `list`
 * `^heading (image paragraph)+$` – one `heading`, followed by pairs of `image` and `paragraph`, but at least one
+
+### Inspecting the Pipeline Context
+
+When run in non-production, i.e. outside an OpenWhisk action, for example in `hlx up`, Pipeline Dumping is enabled. Pipeline Dumping allows developers to easily inspect the `Context` object of each step of the pipeline and can be used to debug pipeline functions and to generate realistic test cases.
+
+Each stage of the pipeline processing will create a file like `$PWD/debug/context_dump_34161BE5KuR0nuFDp/context-2018-9-2-14-18-5.635-step-2.json` inside the `debug` directory. These dumps will be removed when the `node` process ends, so that after stopping `hlx up` the `debug` directory will be clean again. The `-step-n` in the filename indicates the step in the pipeline that has been logged.
+
+A simple example might look like this:
+
+Step 0:
+```json
+{}
+```
+
+Step 1:
+```json
+{
+  "request": {}
+}
+```
+
+Step 2:
+```json
+{
+  "request": {},
+  "content": {
+    "body": "---\ntemplate: Medium\n---\n\n# Bill, Welcome to the future\n> Project Helix\n\n## Let's talk about Project Helix\n![](./moscow/assets/IMG_0167.jpg)\n",
+    "sources": [
+      "https://raw.githubusercontent.com/trieloff/soupdemo/master/hello.md"
+    ]
+  }
+}
+```
+
+Step 3 (diff only):
+```diff
+@@ -1,6 +1,58 @@
+ {
+   "content": {
+-    "body": "Hello World"
++    "body": "Hello World",
++    "mdast": {
++      "type": "root",
++      "children": [
++        {
++          "type": "paragraph",
++          "children": [
++            {
++              "type": "text",
++              "value": "Hello World",
++              "position": {
++                "start": {
++                  "line": 1,
++                  "column": 1,
++                  "offset": 0
++                },
++                "end": {
++                  "line": 1,
++                  "column": 12,
++                  "offset": 11
++                },
++                "indent": []
++              }
++            }
++          ],
++          "position": {
++            "start": {
++              "line": 1,
++              "column": 1,
++              "offset": 0
++            },
++            "end": {
++              "line": 1,
++              "column": 12,
++              "offset": 11
++            },
++            "indent": []
++          }
++        }
++      ],
++      "position": {
++        "start": {
++          "line": 1,
++          "column": 1,
++          "offset": 0
++        },
++        "end": {
++          "line": 1,
++          "column": 12,
++          "offset": 11
++        }
++      }
++    }
+   },
+   "request": {}
+ }
+```
+
+Step 5 (diff only):
+```diff
+@@ -52,7 +52,49 @@
+           "offset": 11
+         }
+       }
+-    }
++    },
++    "sections": [
++      {
++        "type": "root",
++        "children": [
++          {
++            "type": "paragraph",
++            "children": [
++              {
++                "type": "text",
++                "value": "Hello World",
++                "position": {
++                  "start": {
++                    "line": 1,
++                    "column": 1,
++                    "offset": 0
++                  },
++                  "end": {
++                    "line": 1,
++                    "column": 12,
++                    "offset": 11
++                  },
++                  "indent": []
++                }
++              }
++            ],
++            "position": {
++              "start": {
++                "line": 1,
++                "column": 1,
++                "offset": 0
++              },
++              "end": {
++                "line": 1,
++                "column": 12,
++                "offset": 11
++              },
++              "indent": []
++            }
++          }
++        ]
++      }
++    ]
+   },
+   "request": {}
+ }
+ ```
+
+ Step 6 (diff only):
+ ```diff
+@@ -92,9 +92,19 @@
+               "indent": []
+             }
+           }
+-        ]
++        ],
++        "title": "Hello World",
++        "types": [
++          "has-paragraph",
++          "is-paragraph-only"
++        ],
++        "intro": "Hello World",
++        "meta": {}
+       }
+-    ]
++    ],
++    "meta": {},
++    "title": "Hello World",
++    "intro": "Hello World"
+   },
+   "request": {}
+ }
+ ```
+
+ Step 9 (diff only):
+
+ ```diff
+ @@ -169,7 +169,11 @@
+         "search": "",
+         "hash": ""
+       }
+-    }
++    },
++    "html": "<p>Hello World</p>",
++    "children": [
++      "<p>Hello World</p>"
++    ]
+   },
+   "request": {}
+ }
+ ```
+
+ Step 10 (diff only):
+
+ ```diff
+ @@ -175,5 +175,9 @@
+       "<p>Hello World</p>"
+     ]
+   },
+-  "request": {}
++  "request": {},
++  "response": {
++    "status": 201,
++    "body": "<p>Hello World</p>"
++  }
+ }
+ ```

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ In the example above, all sections that have a `heading` as the first child will
 
 When run in non-production, i.e. outside an OpenWhisk action, for example in `hlx up`, Pipeline Dumping is enabled. Pipeline Dumping allows developers to easily inspect the `Context` object of each step of the pipeline and can be used to debug pipeline functions and to generate realistic test cases.
 
-Each stage of the pipeline processing will create a file like `$PWD/debug/context_dump_34161BE5KuR0nuFDp/context-20180902-1418-05.0635-step-2.json` inside the `debug` directory. These dumps will be removed when the `node` process ends, so that after stopping `hlx up` the `debug` directory will be clean again. The `-step-n` in the filename indicates the step in the pipeline that has been logged.
+Each stage of the pipeline processing will create a file like `$PWD/logs/debug/context_dump_34161BE5KuR0nuFDp/context-20180902-1418-05.0635-step-2.json` inside the `debug` directory. These dumps will be removed when the `node` process ends, so that after stopping `hlx up` the `debug` directory will be clean again. The `-step-n` in the filename indicates the step in the pipeline that has been logged.
 
 A simple example might look like this:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6116,6 +6116,15 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "tmp-promise": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.0.5.tgz",
+      "integrity": "sha512-hOabTz9Tp49wCozFwuJe5ISrOqkECm6kzw66XTP23DuzNU7QS/KiZq5LC9Y7QSy8f1rPSLy4bKaViP0OwGI1cA==",
+      "requires": {
+        "bluebird": "3.5.2",
+        "tmp": "0.0.33"
+      }
+    },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "retext": "^5.0.0",
     "retext-smartypants": "^3.0.1",
     "snyk": "^1.88.1",
+    "tmp-promise": "^1.0.5",
     "unified": "^7.0.0",
     "unist-util-find-all-between": "^1.0.2",
     "unist-util-map": "^1.0.4",

--- a/src/defaults/html.pipe.js
+++ b/src/defaults/html.pipe.js
@@ -35,7 +35,8 @@ const htmlpipe = (cont, payload, action) => {
   pipe
     .tap(dump).when(() => !production())
     .pre(adaptOWRequest)
-    .pre(fetch).when(({ content }) => !(content && content.body && content.body.length > 0))
+    .pre(fetch)
+    .when(({ content }) => !(content && content.body && content.body.length > 0))
     .pre(parse)
     .pre(smartypants)
     .pre(sections)

--- a/src/defaults/html.pipe.js
+++ b/src/defaults/html.pipe.js
@@ -33,7 +33,7 @@ const htmlpipe = (cont, payload, action) => {
   action.logger.log('debug', 'Constructing HTML Pipeline');
   const pipe = new Pipeline(action);
   pipe
-    .tap(dump).when(() => !production())
+    .every(dump).when(() => !production())
     .pre(adaptOWRequest)
     .pre(fetch)
     .when(({ content }) => !(content && content.body && content.body.length > 0))

--- a/src/defaults/html.pipe.js
+++ b/src/defaults/html.pipe.js
@@ -23,6 +23,8 @@ const smartypants = require('../html/smartypants');
 const sections = require('../html/split-sections');
 const debug = require('../html/output-debug.js');
 const key = require('../html/set-surrogate-key');
+const production = require('../utils/is-production');
+const dump = require('../utils/dump-context.js');
 
 /* eslint no-param-reassign: off */
 
@@ -31,6 +33,7 @@ const htmlpipe = (cont, payload, action) => {
   action.logger.log('debug', 'Constructing HTML Pipeline');
   const pipe = new Pipeline(action);
   pipe
+    .tap(dump).when(() => !production())
     .pre(adaptOWRequest)
     .pre(fetch).when(({ content }) => !(content && content.body && content.body.length > 0))
     .pre(parse)

--- a/src/defaults/json.pipe.js
+++ b/src/defaults/json.pipe.js
@@ -18,6 +18,8 @@ const meta = require('../html/get-metadata.js');
 const type = require('../json/set-content-type.js');
 const smartypants = require('../html/smartypants');
 const sections = require('../html/split-sections');
+const production = require('../utils/is-production');
+const dump = require('../utils/dump-context.js');
 
 /* eslint no-param-reassign: off */
 
@@ -26,6 +28,7 @@ const htmlpipe = (cont, payload, action) => {
   action.logger.log('debug', 'Constructing JSON Pipeline');
   const pipe = new Pipeline(action);
   pipe
+    .tap(dump).when(() => !production())
     .pre(adaptOWRequest)
     .pre(fetch)
     .pre(parse)

--- a/src/defaults/json.pipe.js
+++ b/src/defaults/json.pipe.js
@@ -28,7 +28,7 @@ const htmlpipe = (cont, payload, action) => {
   action.logger.log('debug', 'Constructing JSON Pipeline');
   const pipe = new Pipeline(action);
   pipe
-    .tap(dump).when(() => !production())
+    .every(dump).when(() => !production())
     .pre(adaptOWRequest)
     .pre(fetch)
     .pre(parse)

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -140,7 +140,7 @@ class Pipeline {
         } if (result) {
           return lastfunc(...args);
         }
-        return args;
+        return args[0];
       };
       this._last.push(wrappedfunc);
     } else {

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -127,18 +127,18 @@ class Pipeline {
   when(predicate) {
     if (this._last && this._last.length > 0) {
       const lastfunc = this._last.pop();
-      const wrappedfunc = (args) => {
-        const result = predicate(args);
+      const wrappedfunc = (...args) => {
+        const result = predicate(args[0]);
         // check if predicate returns a promise like result
         if (_.isFunction(result.then)) {
           return result.then((predResult) => {
             if (predResult) {
-              return lastfunc(args, this._action);
+              return lastfunc(...args);
             }
-            return args;
+            return args[0];
           });
         } if (result) {
-          return lastfunc(args, this._action);
+          return lastfunc(...args);
         }
         return args;
       };

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -42,6 +42,16 @@ const nopLogger = {
 */
 
 /**
+ * Tap function
+ *
+ * @typedef {function(context, _action, index)} tapFunction
+ * @callback tapFunction
+ * @param {Context} context Pipeline execution context that is passed along
+ * @param {Action} action Pipeline action define during construction
+ * @param {number} index index of the function invocation order
+*/
+
+/**
  * Pipeline that allows to execute a list of functions in order. The pipeline consists of 3
  * major function lists: `pre`, `once` and, `post`. the functions added to the `pre` list are
  * processed first, then the `once` function and finally the `post` functions.
@@ -67,6 +77,8 @@ class Pipeline {
     this._oncef = null;
     // functions that are executed after
     this._posts = [];
+    // functions that are executed before each step
+    this._taps = [];
   }
 
   /**
@@ -88,6 +100,18 @@ class Pipeline {
   post(f) {
     this._posts.push(f);
     this._last = this._posts;
+    return this;
+  }
+
+  /**
+   * Adds a tap (observing) function to the pipeline. taps are executed for every
+   * single pipeline step and best used for validation, and logging. taps don't have
+   * any effect, i.e. the return value of a tap function is ignored.
+   * @param {pipelineFunction} f function to be executed in every step. Effects are ignored.
+   */
+  tap(f) {
+    this._taps.push(f);
+    this._last = this._taps;
     return this;
   }
 
@@ -163,12 +187,14 @@ class Pipeline {
      * @param {pipelineFunction} currFunction Function that is currently "reduced"
      * @returns {Promise} Promise resolving to the new value of the accumulator
      */
-    const merge = (currContext, currFunction) => {
+    const merge = (currContext, currFunction, index) => {
       // copy the pipeline payload into a new object to avoid modifications
       const mergedargs = _.merge({}, currContext);
 
       // log the function that is being called and the parameters of the function
-      this._action.logger.silly('processing ', { function: `${currFunction}`, params: mergedargs });
+      this._action.logger.silly('processing ', { function: `${currFunction}`, index, params: mergedargs });
+
+      this._taps.map(f => f(mergedargs, this._action, index));
 
       return Promise.resolve(currFunction(mergedargs, this._action))
         .then((value) => {

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -109,7 +109,7 @@ class Pipeline {
    * any effect, i.e. the return value of a tap function is ignored.
    * @param {pipelineFunction} f function to be executed in every step. Effects are ignored.
    */
-  tap(f) {
+  every(f) {
     this._taps.push(f);
     this._last = this._taps;
     return this;

--- a/src/utils/dump-context.js
+++ b/src/utils/dump-context.js
@@ -17,10 +17,28 @@ const fs = require('fs-extra');
 fs.mkdirpSync(path.resolve(process.cwd(), 'debug'));
 const dumpdir = tmp.dir({ prefix: 'context_dump_', dir: path.resolve(process.cwd(), 'debug'), unsafeCleanup: true }).then(o => o.path);
 
+function tstamp() {
+  const now = new Date();
+  let retstr = '';
+  retstr += ('' + now.getFullYear()).padStart(4, '0');
+  retstr += ('' + now.getUTCMonth()).padStart(2, '0');
+  retstr += ('' + now.getUTCDate()).padStart(2, '0');
+  retstr += '-';
+
+  retstr += ('' + now.getUTCHours()).padStart(2, '0');
+  retstr += ('' + now.getUTCMinutes()).padStart(2, '0');
+  retstr += '-';
+
+  retstr += ('' + now.getUTCSeconds()).padStart(2, '0');
+  retstr += '.';
+  retstr += ('' + now.getUTCMilliseconds()).padStart(4, '0');
+
+  return retstr;
+}
+
 function dump(context, _, index) {
   return Promise.resolve(dumpdir).then((dir) => {
-    const now = new Date();
-    const dumppath = path.resolve(dir, `context-${now.getUTCFullYear()}-${now.getUTCMonth()}-${now.getUTCDay()}-${now.getUTCHours()}-${now.getUTCMinutes()}-${now.getUTCSeconds()}.${now.getUTCMilliseconds()}-step-${index}.json`);
+    const dumppath = path.resolve(dir, `context-${tstamp()}-step-${index}.json`);
     fs.writeJsonSync(dumppath, context, { spaces: 2 });
     return dumppath;
   });

--- a/src/utils/dump-context.js
+++ b/src/utils/dump-context.js
@@ -14,7 +14,7 @@ const tmp = require('tmp-promise');
 const path = require('path');
 const fs = require('fs-extra');
 
-fs.mkdirpSync(path.resolve(process.cwd(), 'debug'));
+fs.mkdirpSync(path.resolve(process.cwd(), 'logs', 'debug'));
 const dumpdir = tmp.dir({ prefix: 'context_dump_', dir: path.resolve(process.cwd(), 'debug'), unsafeCleanup: true }).then(o => o.path);
 
 function tstamp() {

--- a/src/utils/dump-context.js
+++ b/src/utils/dump-context.js
@@ -36,12 +36,11 @@ function tstamp() {
   return retstr;
 }
 
-function dump(context, _, index) {
-  return Promise.resolve(dumpdir).then((dir) => {
-    const dumppath = path.resolve(dir, `context-${tstamp()}-step-${index}.json`);
-    fs.writeJsonSync(dumppath, context, { spaces: 2 });
-    return dumppath;
-  });
+async function dump(context, _, index) {
+  const dir = await dumpdir;
+  const dumppath = path.resolve(dir, `context-${tstamp()}-step-${index}.json`);
+  fs.writeJsonSync(dumppath, context, { spaces: 2 });
+  return dumppath;
 }
 
 module.exports = dump;

--- a/src/utils/dump-context.js
+++ b/src/utils/dump-context.js
@@ -20,18 +20,18 @@ const dumpdir = tmp.dir({ prefix: 'context_dump_', dir: path.resolve(process.cwd
 function tstamp() {
   const now = new Date();
   let retstr = '';
-  retstr += ('' + now.getFullYear()).padStart(4, '0');
-  retstr += ('' + now.getUTCMonth()).padStart(2, '0');
-  retstr += ('' + now.getUTCDate()).padStart(2, '0');
+  retstr += (`${now.getFullYear()}`).padStart(4, '0');
+  retstr += (`${now.getUTCMonth()}`).padStart(2, '0');
+  retstr += (`${now.getUTCDate()}`).padStart(2, '0');
   retstr += '-';
 
-  retstr += ('' + now.getUTCHours()).padStart(2, '0');
-  retstr += ('' + now.getUTCMinutes()).padStart(2, '0');
+  retstr += (`${now.getUTCHours()}`).padStart(2, '0');
+  retstr += (`${now.getUTCMinutes()}`).padStart(2, '0');
   retstr += '-';
 
-  retstr += ('' + now.getUTCSeconds()).padStart(2, '0');
+  retstr += (`${now.getUTCSeconds()}`).padStart(2, '0');
   retstr += '.';
-  retstr += ('' + now.getUTCMilliseconds()).padStart(4, '0');
+  retstr += (`${now.getUTCMilliseconds()}`).padStart(4, '0');
 
   return retstr;
 }

--- a/src/utils/dump-context.js
+++ b/src/utils/dump-context.js
@@ -15,7 +15,7 @@ const path = require('path');
 const fs = require('fs-extra');
 
 fs.mkdirpSync(path.resolve(process.cwd(), 'logs', 'debug'));
-const dumpdir = tmp.dir({ prefix: 'context_dump_', dir: path.resolve(process.cwd(), 'debug'), unsafeCleanup: true }).then(o => o.path);
+const dumpdir = tmp.dir({ prefix: 'context_dump_', dir: path.resolve(process.cwd(), 'logs', 'debug'), unsafeCleanup: true }).then(o => o.path);
 
 function tstamp() {
   const now = new Date();

--- a/src/utils/dump-context.js
+++ b/src/utils/dump-context.js
@@ -14,7 +14,7 @@ const tmp = require('tmp-promise');
 const path = require('path');
 const fs = require('fs-extra');
 
-fs.mkdirpSync(path.resolve(process.cwd(), 'debug');
+fs.mkdirpSync(path.resolve(process.cwd(), 'debug'));
 const dumpdir = tmp.dir({ prefix: 'context_dump_', dir: path.resolve(process.cwd(), 'debug'), unsafeCleanup: true }).then(o => o.path);
 
 function dump(context, _, index) {

--- a/src/utils/dump-context.js
+++ b/src/utils/dump-context.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const tmp = require('tmp-promise');
+const path = require('path');
+const fs = require('fs-extra');
+
+
+const dumpdir = tmp.dir({ prefix: 'context_dump_', dir: path.resolve(process.cwd(), 'debug'), unsafeCleanup: true }).then(o => o.path);
+
+function dump(context, _, index) {
+  return Promise.resolve(dumpdir).then((dir) => {
+    const now = new Date();
+    const dumppath = path.resolve(dir, `context-${now.getUTCFullYear()}-${now.getUTCMonth()}-${now.getUTCDay()}-${now.getUTCHours()}-${now.getUTCMinutes()}-${now.getUTCSeconds()}.${now.getUTCMilliseconds()}-step-${index}.json`);
+    fs.writeJsonSync(dumppath, context, { spaces: 2 });
+    return dumppath;
+  });
+}
+
+module.exports = dump;

--- a/src/utils/dump-context.js
+++ b/src/utils/dump-context.js
@@ -14,7 +14,7 @@ const tmp = require('tmp-promise');
 const path = require('path');
 const fs = require('fs-extra');
 
-
+fs.mkdirpSync(path.resolve(process.cwd(), 'debug');
 const dumpdir = tmp.dir({ prefix: 'context_dump_', dir: path.resolve(process.cwd(), 'debug'), unsafeCleanup: true }).then(o => o.path);
 
 function dump(context, _, index) {

--- a/src/utils/is-production.js
+++ b/src/utils/is-production.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/**
+ * Returns true when run inside an OpenWhisk action, false otherwise.
+ */
+function production() {
+  // eslint-disable-next-line no-underscore-dangle
+  return !!process.env.__OW_ACTIVATION_ID;
+}
+
+module.exports = production;

--- a/test/testDebugTmp.js
+++ b/test/testDebugTmp.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+const fs = require('fs-extra');
+const assert = require('assert');
+const dumper = require('../src/utils/dump-context.js');
+
+describe('Test Temp Context Dumper', () => {
+  it('Creates a temp directory', (done) => {
+    dumper({ foo: 'bar' }, {}, 0).then((file) => {
+      assert.ok(fs.existsSync(file));
+      assert.deepEqual(fs.readJSONSync(file), { foo: 'bar' });
+      done();
+    });
+  });
+});

--- a/test/testHTML.js
+++ b/test/testHTML.js
@@ -200,7 +200,7 @@ describe('Testing HTML Pipeline', () => {
       assert.equal(res.headers['Surrogate-Key'], 'foobar');
 
       dump({}, {}, -1).then((dir) => {
-        const outdir = path.resolve(dir, '..');
+        const outdir = path.dirname(dir);
         const found = fs.readdirSync(outdir)
           .map(file => path.resolve(outdir, file))
           .map(full => fs.existsSync(full))

--- a/test/testHTML.js
+++ b/test/testHTML.js
@@ -199,7 +199,7 @@ describe('Testing HTML Pipeline', () => {
       assert.equal('text/plain', res.headers['Content-Type']);
       assert.equal(res.headers['Surrogate-Key'], 'foobar');
 
-      dump({}, {}, -1).then(dir => {
+      dump({}, {}, -1).then((dir) => {
         const outdir = path.resolve(dir, '..');
         const found = fs.readdirSync(outdir)
           .map(file => path.resolve(outdir, file))
@@ -210,5 +210,4 @@ describe('Testing HTML Pipeline', () => {
       });
     });
   });
-
 });

--- a/test/testHTML.js
+++ b/test/testHTML.js
@@ -12,7 +12,10 @@
 /* eslint-env mocha */
 const assert = require('assert');
 const winston = require('winston');
+const fs = require('fs-extra');
+const path = require('path');
 const { pipe } = require('../src/defaults/html.pipe.js');
+const dump = require('../src/utils/dump-context.js');
 
 const logger = winston.createLogger({
   // tune this for debugging
@@ -170,4 +173,42 @@ describe('Testing HTML Pipeline', () => {
       done();
     });
   });
+
+  it('html.pipe produces debug dumps', (done) => {
+    const result = pipe(
+      ({ content }) => ({
+        response: {
+          status: 201,
+          body: content.html,
+          headers: {
+            'Content-Type': 'text/plain',
+            'Surrogate-Key': 'foobar',
+          },
+        },
+      }),
+      {},
+      {
+        request: { params },
+        secrets,
+        logger,
+      },
+    );
+
+    result.then((res) => {
+      assert.equal(201, res.statusCode);
+      assert.equal('text/plain', res.headers['Content-Type']);
+      assert.equal(res.headers['Surrogate-Key'], 'foobar');
+
+      dump({}, {}, -1).then(dir => {
+        const outdir = path.resolve(dir, '..');
+        const found = fs.readdirSync(outdir)
+          .map(file => path.resolve(outdir, file))
+          .map(full => fs.existsSync(full))
+          .filter(e => !!e);
+        assert.notEqual(found.length, 0);
+        done();
+      });
+    });
+  });
+
 });

--- a/test/testIsProduction.js
+++ b/test/testIsProduction.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+const assert = require('assert');
+const production = require('../src/utils/is-production');
+
+describe('Test Check for Production Environment', () => {
+  it('Detects production environment', () => {
+    // eslint-disable-next-line no-underscore-dangle
+    process.env.__OW_ACTIVATION_ID = 'foo';
+    assert.ok(production());
+    // eslint-disable-next-line no-underscore-dangle
+    delete process.env.__OW_ACTIVATION_ID;
+  });
+
+  it('Detects non-production environment', () => {
+    assert.ok(!production());
+  });
+});

--- a/test/testPipeline.js
+++ b/test/testPipeline.js
@@ -224,7 +224,7 @@ describe('Testing Pipeline', () => {
     new Pipeline({ logger })
       .pre(() => ({ foo: 'bar' }))
       .post(() => ({ bar: 'baz' }))
-      .every((c, a, i) => { if (i === 1) { done(); } })
+      .every((c, a, i) => { if (i === 1) { done(); } return true; })
       .run();
   });
 
@@ -232,9 +232,9 @@ describe('Testing Pipeline', () => {
     new Pipeline({ logger })
       .pre(() => ({ foo: 'bar' }))
       .post(() => ({ bar: 'baz' }))
-      .every((c, a, i) => { if (i === 1) { done(new Error('this is a trap')); } })
+      .every((c, a, i) => { if (i === 1) { done(new Error('this is a trap')); } return true; })
       .when(() => false)
-      .every((c, a, i) => { if (i === 1) { done(); } })
+      .every((c, a, i) => { if (i === 1) { done(); } return true; })
       .when(() => true)
       .run();
   });

--- a/test/testPipeline.js
+++ b/test/testPipeline.js
@@ -224,7 +224,7 @@ describe('Testing Pipeline', () => {
     new Pipeline({ logger })
       .pre(() => ({ foo: 'bar' }))
       .post(() => ({ bar: 'baz' }))
-      .tap((c, a, i) => { if (i === 1) { done(); } })
+      .every((c, a, i) => { if (i === 1) { done(); } })
       .run();
   });
 
@@ -232,9 +232,9 @@ describe('Testing Pipeline', () => {
     new Pipeline({ logger })
       .pre(() => ({ foo: 'bar' }))
       .post(() => ({ bar: 'baz' }))
-      .tap((c, a, i) => { if (i === 1) { done(new Error('this is a trap')); } })
+      .every((c, a, i) => { if (i === 1) { done(new Error('this is a trap')); } })
       .when(() => false)
-      .tap((c, a, i) => { if (i === 1) { done(); } })
+      .every((c, a, i) => { if (i === 1) { done(); } })
       .when(() => true)
       .run();
   });

--- a/test/testPipeline.js
+++ b/test/testPipeline.js
@@ -227,4 +227,15 @@ describe('Testing Pipeline', () => {
       .tap((c, a, i) => { if (i === 1) { done(); } })
       .run();
   });
+
+  it('Does not executes taps when conditions fail', (done) => {
+    new Pipeline({ logger })
+      .pre(() => ({ foo: 'bar' }))
+      .post(() => ({ bar: 'baz' }))
+      .tap((c, a, i) => { if (i === 1) { done(new Error('this is a trap')); } })
+      .when(() => false)
+      .tap((c, a, i) => { if (i === 1) { done(); } })
+      .when(() => true)
+      .run();
+  });
 });

--- a/test/testPipeline.js
+++ b/test/testPipeline.js
@@ -219,4 +219,12 @@ describe('Testing Pipeline', () => {
       done();
     });
   });
+
+  it('Executes taps', (done) => {
+    new Pipeline({ logger })
+      .pre(() => ({ foo: 'bar' }))
+      .post(() => ({ bar: 'baz' }))
+      .tap((c, a, i) => { if (i === 1) { done(); } })
+      .run();
+  });
 });


### PR DESCRIPTION
This fixes #14 and provides an alternative to #19:

when running in development-mode (i.e. no OpenWhisk in sight), every step of pipeline processing will be dumped in the `debug` directory. This allows for very fine-grained inspection of the pipeline processing.

The new `Pipeline.tap` helper function allows the registration of effect-less observers or validators.