### PR TITLE
tap logs not usefully grouped #89

### DIFF
--- a/docs/action.schema.json
+++ b/docs/action.schema.json
@@ -25,6 +25,10 @@
             "type": "object",
             "description": "A [Winston](https://github.com/winstonjs/winston) logger instance."
         },
+        "debug": {
+            "type": "object",
+            "description": "Internal information related to debugging."
+        },
         "secrets": {
             "$ref": "https://ns.adobe.com/helix/pipeline/secrets"
         }

--- a/docs/action.schema.md
+++ b/docs/action.schema.md
@@ -21,9 +21,33 @@ Tracks the OpenWhisk action invocation
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
+| [debug](#debug) | `object` | Optional | Action (this schema) |
 | [logger](#logger) | `object` | Optional | Action (this schema) |
 | [request](#request) | Raw Request | Optional | Action (this schema) |
 | [secrets](#secrets) | Secrets | Optional | Action (this schema) |
+
+## debug
+
+Internal information related to debugging.
+
+`debug`
+* is optional
+* type: `object`
+* defined in this schema
+
+### debug Type
+
+
+`object` with following properties:
+
+
+| Property | Type | Required |
+|----------|------|----------|
+
+
+
+
+
 
 ## logger
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "retext": "^5.0.0",
     "retext-smartypants": "^3.0.1",
     "snyk": "^1.88.1",
-    "tmp": "0.0.33",
     "unified": "^7.0.0",
     "unist-util-find-all-between": "^1.0.2",
     "unist-util-map": "^1.0.4",

--- a/src/action.d.ts
+++ b/src/action.d.ts
@@ -84,6 +84,12 @@ export interface Action {
   logger?: {
     [k: string]: any;
   };
+  /**
+   * Internal information related to debugging.
+   */
+  debug?: {
+    [k: string]: any;
+  };
   secrets?: Secrets;
 }
 /**

--- a/src/schemas/action.schema.json
+++ b/src/schemas/action.schema.json
@@ -25,6 +25,10 @@
       "type": "object",
       "description": "A [Winston](https://github.com/winstonjs/winston) logger instance."
     },
+    "debug": {
+      "type": "object",
+      "description": "Internal information related to debugging."
+    },
     "secrets": {
       "$ref": "https://ns.adobe.com/helix/pipeline/secrets"
     }


### PR DESCRIPTION
see #89 

**Note**: I removed the `tmp` dependency, as it would always create random chars for the directory name, which cannot be disabled. also, its feature to cleanup automatically never worked for me. I think it doesn't work, if the process is stopped with `ctrl+c`.

example layout:

```
logs/debug/
├── context_dump_20181006-0156-29.0414_e23c5b809a418618e7fe1815f373f90a/
│   ├── context-20181006-0156-29.0414-step-0.json
│   └── context-20181006-0156-29.0469-step-12.json
├── context_dump_20181006-0158-53.0514_43e4948ff00588cbbc5e66e453ad4ae8/
│   ├── context-20181006-0158-53.0514-step-0.json
│   └── context-20181006-0158-53.0572-step-12.json
└── context_dump_20181006-0159-59.0749_e9216df0c300fa922b70c674bc0dc62c/
    ├── context-20181006-0159-59.0749-step-0.json
    ├── context-20181006-0200-01.0596-step-1.json
    ├── context-20181006-0200-01.0639-step-2.json
    └── context-20181006-0200-01.0643-step-12.json
```