### PR TITLE
Mark sections as hidden when strain parameter does not match

### DIFF
--- a/src/defaults/conditional-sections.js
+++ b/src/defaults/conditional-sections.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+function strain({content}, {request, logger}) {
+  // this only works when there are multiple sections and a strain has been chosen
+  if (request.params && 
+      request.params.strain && 
+      content && 
+      content.sections && 
+      content.sections.length) {
+    const strain = request.params.strain;
+    const sections = content.sections;
+    logger.debug('Filtering sections not intended for strain ' + strain);
+    const remaining = sections.filter(section => {
+      return true;
+    });
+    logger.debug(remaining.length + 'Sections remaining');
+    return {
+      content: {
+        sections: remaining
+      }
+    }
+  }
+}

--- a/src/defaults/conditional-sections.js
+++ b/src/defaults/conditional-sections.js
@@ -21,6 +21,16 @@ function strain({content}, {request, logger}) {
     const sections = content.sections;
     logger.debug('Filtering sections not intended for strain ' + strain);
     const remaining = sections.filter(section => {
+      if (section.meta && section.meta.strain && Array.isArray(section.meta.strain)) {
+        // this is a list of strains
+        // return true if the selected strain is somewhere in the array
+        return section.meta.strain.includes(strain);
+      } else if (section.meta && section.meta.strain) {
+        // we treat it as a string
+        // return true if the selected strain is in the metadata
+        return section.meta.strain === strain;
+      }
+      // if there is no metadata, or no strain selection, just include it
       return true;
     });
     logger.debug(remaining.length + 'Sections remaining');
@@ -31,3 +41,5 @@ function strain({content}, {request, logger}) {
     }
   }
 }
+
+module.exports.strain = strain;

--- a/src/defaults/html.pipe.js
+++ b/src/defaults/html.pipe.js
@@ -22,6 +22,7 @@ const type = require('../html/set-content-type.js');
 const status = require('../html/set-status.js');
 const smartypants = require('../html/smartypants');
 const sections = require('../html/split-sections');
+const { selectstrain } = require('../utils/conditional-sections');
 const debug = require('../html/output-debug.js');
 const key = require('../html/set-surrogate-key');
 const production = require('../utils/is-production');
@@ -43,6 +44,7 @@ const htmlpipe = (cont, payload, action) => {
     .before(smartypants)
     .before(sections)
     .before(meta)
+    .before(selectstrain)
     .before(html)
     .before(responsive)
     .before(emit)

--- a/src/schemas/rawrequest.schema.json
+++ b/src/schemas/rawrequest.schema.json
@@ -82,6 +82,10 @@
               "type": "string",
               "description": "Path to the requested (Markdown) file"
             },
+            "strain": {
+              "type": "string",
+              "description": "The resolved strain (variant)"
+            },
             "__ow_headers": {
               "type": "object",
               "description": "Deprecated: The original OpenWhisk request headers"

--- a/src/utils/conditional-sections.js
+++ b/src/utils/conditional-sections.js
@@ -10,22 +10,22 @@
  * governing permissions and limitations under the License.
  */
 
-function strain({content}, {request, logger}) {
+function strain({ content }, { request, logger }) {
   // this only works when there are multiple sections and a strain has been chosen
-  if (request.params && 
-      request.params.strain && 
-      content && 
-      content.sections && 
-      content.sections.length) {
+  if (request.params
+      && request.params.strain
+      && content
+      && content.sections
+      && content.sections.length) {
     const strain = request.params.strain;
     const sections = content.sections;
-    logger.debug('Filtering sections not intended for strain ' + strain);
-    const remaining = sections.filter(section => {
+    logger.debug(`Filtering sections not intended for strain ${strain}`);
+    const remaining = sections.filter((section) => {
       if (section.meta && section.meta.strain && Array.isArray(section.meta.strain)) {
         // this is a list of strains
         // return true if the selected strain is somewhere in the array
         return section.meta.strain.includes(strain);
-      } else if (section.meta && section.meta.strain) {
+      } if (section.meta && section.meta.strain) {
         // we treat it as a string
         // return true if the selected strain is in the metadata
         return section.meta.strain === strain;
@@ -33,13 +33,14 @@ function strain({content}, {request, logger}) {
       // if there is no metadata, or no strain selection, just include it
       return true;
     });
-    logger.debug(remaining.length + 'Sections remaining');
+    logger.debug(`${remaining.length}Sections remaining`);
     return {
       content: {
-        sections: remaining
-      }
-    }
+        sections: remaining,
+      },
+    };
   }
+  return {};
 }
 
 module.exports.strain = strain;

--- a/src/utils/conditional-sections.js
+++ b/src/utils/conditional-sections.js
@@ -20,20 +20,34 @@ function selectstrain({ content }, { request, logger }) {
     const { strain } = request.params;
     const { sections } = content;
     logger.debug(`Filtering sections not intended for strain ${strain}`);
-    const remaining = sections.filter((section) => {
+    const remaining = sections.map((section) => {
       if (section.meta && section.meta.strain && Array.isArray(section.meta.strain)) {
         // this is a list of strains
         // return true if the selected strain is somewhere in the array
-        return section.meta.strain.includes(strain);
+        return {
+          meta: {
+            type: 'array',
+            hidden: !section.meta.strain.includes(strain),
+          },
+        };
       } if (section.meta && section.meta.strain) {
         // we treat it as a string
         // return true if the selected strain is in the metadata
-        return section.meta.strain === strain;
+        return {
+          meta: {
+            type: 'string',
+            hidden: !(section.meta.strain === strain),
+          },
+        };
       }
       // if there is no metadata, or no strain selection, just include it
-      return true;
+      return {
+        meta: {
+          hidden: false,
+        },
+      };
     });
-    logger.debug(`${remaining.length}Sections remaining`);
+    logger.debug(`${remaining.length} Sections remaining`);
     return {
       content: {
         sections: remaining,

--- a/src/utils/conditional-sections.js
+++ b/src/utils/conditional-sections.js
@@ -10,15 +10,15 @@
  * governing permissions and limitations under the License.
  */
 
-function strain({ content }, { request, logger }) {
+function selectstrain({ content }, { request, logger }) {
   // this only works when there are multiple sections and a strain has been chosen
   if (request.params
       && request.params.strain
       && content
       && content.sections
       && content.sections.length) {
-    const strain = request.params.strain;
-    const sections = content.sections;
+    const { strain } = request.params;
+    const { sections } = content;
     logger.debug(`Filtering sections not intended for strain ${strain}`);
     const remaining = sections.filter((section) => {
       if (section.meta && section.meta.strain && Array.isArray(section.meta.strain)) {
@@ -43,4 +43,4 @@ function strain({ content }, { request, logger }) {
   return {};
 }
 
-module.exports.strain = strain;
+module.exports.selectstrain = selectstrain;

--- a/test/testConditionalSections.js
+++ b/test/testConditionalSections.js
@@ -13,7 +13,7 @@
 
 const assert = require('assert');
 const winston = require('winston');
-const { strain } = require('../src/utils/conditional-sections');
+const { selectstrain } = require('../src/utils/conditional-sections');
 
 const logger = winston.createLogger({
   // tune this for debugging
@@ -40,7 +40,7 @@ describe('Unit Test Section Strain Filtering', () => {
         },
       },
     };
-    const result = strain(context, action);
+    const result = selectstrain(context, action);
     assert.deepStrictEqual(result, {});
   });
 
@@ -62,7 +62,7 @@ describe('Unit Test Section Strain Filtering', () => {
       },
       logger,
     };
-    const result = strain(context, action);
+    const result = selectstrain(context, action);
     assert.equal(result.content.sections.length, 2);
   });
 
@@ -84,7 +84,7 @@ describe('Unit Test Section Strain Filtering', () => {
       },
       logger,
     };
-    const result = strain(context, action);
+    const result = selectstrain(context, action);
     assert.equal(result.content.sections.length, 2);
   });
 
@@ -107,7 +107,7 @@ describe('Unit Test Section Strain Filtering', () => {
       },
       logger,
     };
-    const result = strain(context, action);
+    const result = selectstrain(context, action);
     assert.equal(result.content.sections.length, 2);
   });
 
@@ -129,7 +129,7 @@ describe('Unit Test Section Strain Filtering', () => {
       },
       logger,
     };
-    const result = strain(context, action);
+    const result = selectstrain(context, action);
     assert.equal(result.content.sections.length, 2);
   });
 });

--- a/test/testConditionalSections.js
+++ b/test/testConditionalSections.js
@@ -13,6 +13,7 @@
 
 const assert = require('assert');
 const winston = require('winston');
+const { pipe } = require('../src/defaults/html.pipe.js');
 const { selectstrain } = require('../src/utils/conditional-sections');
 
 const logger = winston.createLogger({
@@ -21,9 +22,77 @@ const logger = winston.createLogger({
   // and turn this on if you want the output
   silent: true,
   format: winston.format.simple(),
-  transports: [
-    new winston.transports.Console(),
-  ],
+  transports: [new winston.transports.Console()],
+});
+
+const params = {
+  path: '/hello.md',
+  __ow_method: 'get',
+  owner: 'trieloff',
+  __ow_headers: {
+    'X-Forwarded-Port': '443',
+    'X-CDN-Request-Id': '2a208a89-e071-44cf-aee9-220880da4c1e',
+    'Fastly-Client': '1',
+    'X-Forwarded-Host': 'runtime.adobe.io',
+    'Upgrade-Insecure-Requests': '1',
+    Host: 'controller-a',
+    Connection: 'close',
+    'Fastly-SSL': '1',
+    'X-Request-Id': 'RUss5tPdgOfw74a68aNc24FeTipGpVfW',
+    'X-Branch': 'master',
+    'Accept-Language': 'en-US, en;q=0.9, de;q=0.8',
+    'X-Forwarded-Proto': 'https',
+    'Fastly-Orig-Accept-Encoding': 'gzip',
+    'X-Varnish': '267021320',
+    DNT: '1',
+    'X-Forwarded-For':
+      '192.147.117.11, 157.52.92.27, 23.235.46.33, 10.64.221.107',
+    'X-Host': 'www.primordialsoup.life',
+    Accept:
+      'text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, image/apng, */*;q=0.8',
+    'X-Real-IP': '10.64.221.107',
+    'X-Forwarded-Server': 'cache-lcy19249-LCY, cache-iad2127-IAD',
+    'Fastly-Client-IP': '192.147.117.11',
+    'Perf-Br-Req-In': '1529585370.116',
+    'X-Timer': 'S1529585370.068237,VS0,VS0',
+    'Fastly-FF':
+      'dc/x3e9z8KMmlHLQr8BEvVMmTcpl3y2YY5y6gjSJa3g=!LCY!cache-lcy19249-LCY, dc/x3e9z8KMmlHLQr8BEvVMmTcpl3y2YY5y6gjSJa3g=!LCY!cache-lcy19227-LCY, dc/x3e9z8KMmlHLQr8BEvVMmTcpl3y2YY5y6gjSJa3g=!IAD!cache-iad2127-IAD, dc/x3e9z8KMmlHLQr8BEvVMmTcpl3y2YY5y6gjSJa3g=!IAD!cache-iad2133-IAD',
+    'Accept-Encoding': 'gzip',
+    'User-Agent':
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36',
+  },
+  repo: 'soupdemo',
+  ref: 'master',
+  selector: 'md',
+};
+
+const secrets = {
+  REPO_RAW_ROOT: 'https://raw.githubusercontent.com/',
+};
+
+describe('Integration Test Section Strain Filtering', () => {
+  it('html.pipe sees only selected section', async () => {
+    const myparams = Object.assign({ strain: 'a' }, params);
+
+    await pipe(
+      ({ content }) => {
+        // this is the main function (normally it would be the template function)
+        // but we use it to assert that pre-processing has happened
+        assert.equal(content.sections.length, 1);
+        return { response: { body: content.html } };
+      },
+      {
+        content: {
+          body: 'Hello World',
+        },
+      },
+      {
+        request: { myparams },
+        secrets,
+        logger,
+      },
+    );
+  });
 });
 
 describe('Unit Test Section Strain Filtering', () => {
@@ -87,7 +156,6 @@ describe('Unit Test Section Strain Filtering', () => {
     const result = selectstrain(context, action);
     assert.equal(result.content.sections.length, 2);
   });
-
 
   it('Keeps sections without a strain', () => {
     const context = {

--- a/test/testConditionalSections.js
+++ b/test/testConditionalSections.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+
+const assert = require('assert');
+const winston = require('winston');
+const { strain } = require('../src/utils/conditional-sections');
+
+const logger = winston.createLogger({
+  // tune this for debugging
+  level: 'debug',
+  // and turn this on if you want the output
+  silent: true,
+  format: winston.format.simple(),
+  transports: [
+    new winston.transports.Console(),
+  ],
+});
+
+describe('Unit Test Section Strain Filtering', () => {
+  it('Works with empty section lists', () => {
+    const context = {
+      content: {
+        sections: [],
+      },
+    };
+    const action = {
+      request: {
+        params: {
+          strain: 'empty',
+        },
+      },
+    };
+    const result = strain(context, action);
+    assert.deepStrictEqual(result, {});
+  });
+
+  it('Filters sections based on strain', () => {
+    const context = {
+      content: {
+        sections: [
+          { meta: { strain: 'test' } },
+          { meta: { strain: 'test' } },
+          { meta: { strain: 'no-test' } },
+        ],
+      },
+    };
+    const action = {
+      request: {
+        params: {
+          strain: 'test',
+        },
+      },
+      logger,
+    };
+    const result = strain(context, action);
+    assert.equal(result.content.sections.length, 2);
+  });
+
+  it('Filters sections based on strain (array)', () => {
+    const context = {
+      content: {
+        sections: [
+          { meta: { strain: 'test' } },
+          { meta: { strain: ['test', 'no-test'] } },
+          { meta: { strain: 'no-test' } },
+        ],
+      },
+    };
+    const action = {
+      request: {
+        params: {
+          strain: 'test',
+        },
+      },
+      logger,
+    };
+    const result = strain(context, action);
+    assert.equal(result.content.sections.length, 2);
+  });
+
+
+  it('Keeps sections without a strain', () => {
+    const context = {
+      content: {
+        sections: [
+          { meta: { strain: 'test' } },
+          { meta: { strain: ['test', 'no-test'] } },
+          { meta: {} },
+        ],
+      },
+    };
+    const action = {
+      request: {
+        params: {
+          strain: 'no-test',
+        },
+      },
+      logger,
+    };
+    const result = strain(context, action);
+    assert.equal(result.content.sections.length, 2);
+  });
+
+  it('Keeps sections without metadata', () => {
+    const context = {
+      content: {
+        sections: [
+          { meta: { strain: 'test' } },
+          { meta: { strain: ['test', 'no-test'] } },
+          {},
+        ],
+      },
+    };
+    const action = {
+      request: {
+        params: {
+          strain: 'no-test',
+        },
+      },
+      logger,
+    };
+    const result = strain(context, action);
+    assert.equal(result.content.sections.length, 2);
+  });
+});

--- a/test/testConditionalSections.js
+++ b/test/testConditionalSections.js
@@ -73,25 +73,47 @@ const secrets = {
 describe('Integration Test Section Strain Filtering', () => {
   it('html.pipe sees only selected section', async () => {
     const myparams = Object.assign({ strain: 'a' }, params);
-
-    await pipe(
+    console.log('hi');
+    const result = await pipe(
       ({ content }) => {
         // this is the main function (normally it would be the template function)
         // but we use it to assert that pre-processing has happened
+        console.log(content.sections);
         assert.equal(content.sections.length, 1);
         return { response: { body: content.html } };
       },
       {
         content: {
-          body: 'Hello World',
+          body: `This is an easy test.
+
+---
+
+These two sections should always be shown
+
+---
+strain: a
+---
+
+But this one only in strain "A"
+
+---
+strain: b
+---
+
+And this one only in strain "B"
+
+`,
         },
       },
       {
-        request: { myparams },
+        request: { params: myparams },
         secrets,
         logger,
       },
     );
+    console.log(result);
+    assert.equal(result.error, null);
+    assert.equal(200, result.response.status);
   });
 });
 


### PR DESCRIPTION
This is a partial implementation of #57, it will mark all sections that have a `strain` metadata value that does not match the currently selected strain as `hidden: true`. The sections are not actually removed, but should be skipped when rendering.