### PR TITLE
Refactor defaults

### DIFF
--- a/docs/secrets.schema.json
+++ b/docs/secrets.schema.json
@@ -30,27 +30,33 @@
         },
         "EMBED_WHITELIST": {
             "type": "string",
-            "description": "Comma-separated list of allowed hostnames for embeds. Supports `*.example.com` as a subdomain wildcard. Use `*` to allow all embeds (potentially insecure)"
+            "description": "Comma-separated list of allowed hostnames for embeds. Supports `*.example.com` as a subdomain wildcard. Use `*` to allow all embeds (potentially insecure)",
+            "default": "www.youtube.com, spark.adobe.com, unsplash.com/photos"
         },
         "EMBED_SERVICE": {
             "type": "string",
-            "description": "URL of an Embed Service that takes the appended URL and returns an embeddable HTML representation."
+            "description": "URL of an Embed Service that takes the appended URL and returns an embeddable HTML representation.",
+            "default": "https://adobeioruntime.net/api/v1/web/helix/default/embed/"
         },
         "IMAGES_MIN_SIZE": {
-            "type": "string",
-            "description": "Minimum physical width of responsive images to generate"
+            "type": "integer",
+            "description": "Minimum physical width of responsive images to generate",
+            "default": 480
         },
         "IMAGES_MAX_SIZE": {
-            "type": "string",
-            "description": "Maximum physical with of responsive images to generate"
+            "type": "integer",
+            "description": "Maximum physical with of responsive images to generate",
+            "default": 4096
         },
         "IMAGES_SIZE_STEPS": {
-            "type": "string",
-            "description": "Number of intermediary size steps to create per image"
+            "type": "integer",
+            "description": "Number of intermediary size steps to create per image",
+            "default": 4
         },
         "IMAGES_SIZES": {
             "type": "string",
-            "description": "Value for the `sizes` attribute of generated responsive images"
+            "description": "Value for the `sizes` attribute of generated responsive images",
+            "default": "100vw"
         }
     }
 }

--- a/docs/secrets.schema.json
+++ b/docs/secrets.schema.json
@@ -19,14 +19,26 @@
     "description": "Secrets passed into the pipeline such as API Keys or configuration settings.",
     "patternProperties": {
         "[A-Z0-9_]+": {
-            "type": "string"
+            "type": [
+                "boolean",
+                "integer",
+                "number",
+                "string"
+            ]
         }
     },
     "properties": {
         "REPO_RAW_ROOT": {
             "type": "string",
+            "format": "uri",
             "description": "The Base URL for retrieving raw text files from GitHub",
             "default": "https://raw.githubusercontent.com/"
+        },
+        "REPO_API_ROOT": {
+            "type": "string",
+            "format": "uri",
+            "description": "The base URL for all GitHub API operations",
+            "default": "https://api.github.com/"
         },
         "EMBED_WHITELIST": {
             "type": "string",
@@ -57,6 +69,10 @@
             "type": "string",
             "description": "Value for the `sizes` attribute of generated responsive images",
             "default": "100vw"
+        },
+        "TEST_BOOLEAN": {
+            "type": "boolean",
+            "default": true
         }
     }
 }

--- a/docs/secrets.schema.md
+++ b/docs/secrets.schema.md
@@ -21,8 +21,10 @@ Secrets passed into the pipeline such as API Keys or configuration settings.
 | [IMAGES_MIN_SIZE](#images_min_size) | `integer` | Optional | `480` | Secrets (this schema) |
 | [IMAGES_SIZES](#images_sizes) | `string` | Optional | `"100vw"` | Secrets (this schema) |
 | [IMAGES_SIZE_STEPS](#images_size_steps) | `integer` | Optional | `4` | Secrets (this schema) |
+| [REPO_API_ROOT](#repo_api_root) | `string` | Optional | `"https://api.github.com/"` | Secrets (this schema) |
 | [REPO_RAW_ROOT](#repo_raw_root) | `string` | Optional | `"https://raw.githubusercontent.com/"` | Secrets (this schema) |
-| `[A-Z0-9_]+` | `string` | Pattern |  | Secrets (this schema) |
+| [TEST_BOOLEAN](#test_boolean) | `boolean` | Optional | `true` | Secrets (this schema) |
+| `[A-Z0-9_]+` | complex | Pattern |  | Secrets (this schema) |
 
 ## EMBED_SERVICE
 
@@ -144,6 +146,27 @@ Number of intermediary size steps to create per image
 
 
 
+## REPO_API_ROOT
+
+The base URL for all GitHub API operations
+
+`REPO_API_ROOT`
+* is optional
+* type: `string`
+* default: `"https://api.github.com/"`
+* defined in this schema
+
+### REPO_API_ROOT Type
+
+
+`string`
+* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
+
+
+
+
+
+
 ## REPO_RAW_ROOT
 
 The Base URL for retrieving raw text files from GitHub
@@ -158,7 +181,26 @@ The Base URL for retrieving raw text files from GitHub
 
 
 `string`
+* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
+
+
+
+
+
+## TEST_BOOLEAN
+
+
+`TEST_BOOLEAN`
+* is optional
+* type: `boolean`
+* default: `true`
+* defined in this schema
+
+### TEST_BOOLEAN Type
+
+
+`boolean`
 
 
 
@@ -170,14 +212,24 @@ Applies to all properties that match the regular expression `[A-Z0-9_]+`
 
 `[A-Z0-9_]+`
 * is a property pattern
-* type: `string`
+* type: complex
 * defined in this schema
 
 ### Pattern [A-Z0-9_]+ Type
 
+Unknown type `boolean,integer,number,string`.
 
-`string`
-
+```json
+{
+  "type": [
+    "boolean",
+    "integer",
+    "number",
+    "string"
+  ],
+  "simpletype": "complex"
+}
+```
 
 
 

--- a/docs/secrets.schema.md
+++ b/docs/secrets.schema.md
@@ -15,12 +15,12 @@ Secrets passed into the pipeline such as API Keys or configuration settings.
 
 | Property | Type | Required | Default | Defined by |
 |----------|------|----------|---------|------------|
-| [EMBED_SERVICE](#embed_service) | `string` | Optional |  | Secrets (this schema) |
-| [EMBED_WHITELIST](#embed_whitelist) | `string` | Optional |  | Secrets (this schema) |
-| [IMAGES_MAX_SIZE](#images_max_size) | `string` | Optional |  | Secrets (this schema) |
-| [IMAGES_MIN_SIZE](#images_min_size) | `string` | Optional |  | Secrets (this schema) |
-| [IMAGES_SIZES](#images_sizes) | `string` | Optional |  | Secrets (this schema) |
-| [IMAGES_SIZE_STEPS](#images_size_steps) | `string` | Optional |  | Secrets (this schema) |
+| [EMBED_SERVICE](#embed_service) | `string` | Optional | `"https://adobeioruntime.net/api/v1/web/helix/default/embed/"` | Secrets (this schema) |
+| [EMBED_WHITELIST](#embed_whitelist) | `string` | Optional | `"www.youtube.com, spark.adobe.com, unsplash.com/photos"` | Secrets (this schema) |
+| [IMAGES_MAX_SIZE](#images_max_size) | `integer` | Optional | `4096` | Secrets (this schema) |
+| [IMAGES_MIN_SIZE](#images_min_size) | `integer` | Optional | `480` | Secrets (this schema) |
+| [IMAGES_SIZES](#images_sizes) | `string` | Optional | `"100vw"` | Secrets (this schema) |
+| [IMAGES_SIZE_STEPS](#images_size_steps) | `integer` | Optional | `4` | Secrets (this schema) |
 | [REPO_RAW_ROOT](#repo_raw_root) | `string` | Optional | `"https://raw.githubusercontent.com/"` | Secrets (this schema) |
 | `[A-Z0-9_]+` | `string` | Pattern |  | Secrets (this schema) |
 
@@ -31,6 +31,7 @@ URL of an Embed Service that takes the appended URL and returns an embeddable HT
 `EMBED_SERVICE`
 * is optional
 * type: `string`
+* default: `"https://adobeioruntime.net/api/v1/web/helix/default/embed/"`
 * defined in this schema
 
 ### EMBED_SERVICE Type
@@ -50,6 +51,7 @@ Comma-separated list of allowed hostnames for embeds. Supports `*.example.com` a
 `EMBED_WHITELIST`
 * is optional
 * type: `string`
+* default: `"www.youtube.com, spark.adobe.com, unsplash.com/photos"`
 * defined in this schema
 
 ### EMBED_WHITELIST Type
@@ -68,13 +70,14 @@ Maximum physical with of responsive images to generate
 
 `IMAGES_MAX_SIZE`
 * is optional
-* type: `string`
+* type: `integer`
+* default: `4096`
 * defined in this schema
 
 ### IMAGES_MAX_SIZE Type
 
 
-`string`
+`integer`
 
 
 
@@ -87,13 +90,14 @@ Minimum physical width of responsive images to generate
 
 `IMAGES_MIN_SIZE`
 * is optional
-* type: `string`
+* type: `integer`
+* default: `480`
 * defined in this schema
 
 ### IMAGES_MIN_SIZE Type
 
 
-`string`
+`integer`
 
 
 
@@ -107,6 +111,7 @@ Value for the `sizes` attribute of generated responsive images
 `IMAGES_SIZES`
 * is optional
 * type: `string`
+* default: `"100vw"`
 * defined in this schema
 
 ### IMAGES_SIZES Type
@@ -125,13 +130,14 @@ Number of intermediary size steps to create per image
 
 `IMAGES_SIZE_STEPS`
 * is optional
-* type: `string`
+* type: `integer`
+* default: `4`
 * defined in this schema
 
 ### IMAGES_SIZE_STEPS Type
 
 
-`string`
+`integer`
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -438,7 +438,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-includes": {
@@ -2704,11 +2704,11 @@
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.0.tgz",
       "integrity": "sha512-A7ev5OseS/J15214cvDdcI62uwovJO2PB60Xhnq7kaxvvQRFDEccuqbkrFXU03GPBGopdPqlpQBRqIcDS/Fjbg==",
       "requires": {
-        "ccount": "^1.0.3",
-        "hastscript": "^5.0.0",
-        "property-information": "^5.0.0",
-        "web-namespaces": "^1.1.2",
-        "xtend": "^4.0.1"
+        "ccount": "1.0.3",
+        "hastscript": "5.0.0",
+        "property-information": "5.0.1",
+        "web-namespaces": "1.1.2",
+        "xtend": "4.0.1"
       }
     },
     "hast-util-is-element": {
@@ -2758,10 +2758,10 @@
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.0.0.tgz",
       "integrity": "sha512-xJtuJ8D42Xtq5yJrnDg/KAIxl2cXBXKoiIJwmWX9XMf8113qHTGl/Bf7jEsxmENJ4w6q4Tfl8s/Y6mEZo8x8qw==",
       "requires": {
-        "comma-separated-tokens": "^1.0.0",
-        "hast-util-parse-selector": "^2.2.0",
-        "property-information": "^5.0.1",
-        "space-separated-tokens": "^1.0.0"
+        "comma-separated-tokens": "1.0.5",
+        "hast-util-parse-selector": "2.2.1",
+        "property-information": "5.0.1",
+        "space-separated-tokens": "1.1.2"
       }
     },
     "he": {
@@ -4212,7 +4212,6 @@
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "3.2.2",
             "longest": "1.0.1",
@@ -4579,8 +4578,7 @@
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -4691,7 +4689,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "1.1.6"
           }
@@ -4744,8 +4741,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -5048,8 +5044,7 @@
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -5505,6 +5500,11 @@
         }
       }
     },
+    "object-hash": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
+    },
     "object-keys": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
@@ -5898,7 +5898,7 @@
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.0.1.tgz",
       "integrity": "sha512-nAtBDVeSwFM3Ot/YxT7s4NqZmqXI7lLzf46BThvotEtYf2uk2yH0ACYuWQkJ7gxKs49PPtKVY0UlDGkyN9aJlw==",
       "requires": {
-        "xtend": "^4.0.1"
+        "xtend": "4.0.1"
       }
     },
     "proxy-agent": {
@@ -6068,9 +6068,9 @@
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.0.tgz",
       "integrity": "sha512-V2OjMD0xcSt39G4uRdMTqDXXm6HwkUbLMDayYKA/d037j8/OtVSQ+tqKwYWOuyBeoCs/3clXRe30VUjeMDTBSA==",
       "requires": {
-        "hast-util-from-parse5": "^5.0.0",
-        "parse5": "^5.0.0",
-        "xtend": "^4.0.1"
+        "hast-util-from-parse5": "5.0.0",
+        "parse5": "5.1.0",
+        "xtend": "4.0.1"
       }
     },
     "remark-frontmatter": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "mdast-util-to-string": "^1.0.4",
     "mdurl": "^1.0.1",
     "micromatch": "^3.1.10",
+    "object-hash": "^1.3.1",
     "rehype-parse": "^6.0.0",
     "remark-frontmatter": "^1.3.0",
     "remark-parse": "^6.0.0",

--- a/src/html/embed-whitelist.json
+++ b/src/html/embed-whitelist.json
@@ -1,3 +1,0 @@
-[
-  "www.youtube.com"
-]

--- a/src/html/fetch-markdown.js
+++ b/src/html/fetch-markdown.js
@@ -13,8 +13,6 @@ const client = require('request-promise-native');
 const URI = require('uri-js');
 const { bail } = require('../helper');
 
-const GH_RAW = 'https://raw.githubusercontent.com/';
-
 function uri(root, owner, repo, ref, path) {
   const rootURI = URI.parse(root);
   const rootPath = rootURI.path;
@@ -73,7 +71,7 @@ async function fetch(
     return bail(logger, 'Unknown path, cannot fetch content');
   }
 
-  const { REPO_RAW_ROOT: rootPath = GH_RAW } = secrets;
+  const { REPO_RAW_ROOT: rootPath } = secrets;
 
   // everything looks good, make the HTTP request
   const options = {

--- a/src/html/find-embeds.js
+++ b/src/html/find-embeds.js
@@ -13,7 +13,6 @@
 const map = require('unist-util-map');
 const URI = require('uri-js');
 const mm = require('micromatch');
-const defaultwhitelist = require('./embed-whitelist.json');
 
 /**
  * Finds embeds like `video: https://www.youtube.com/embed/2Xc9gXyf2G4`
@@ -66,7 +65,7 @@ function embed(uri, node, whitelist = '', warn = () => {}) {
   }
 }
 
-function find({ content: { mdast } }, { logger, secrets: { EMBED_WHITELIST = defaultwhitelist.join(',') } = {} }) {
+function find({ content: { mdast } }, { logger, secrets: { EMBED_WHITELIST } }) {
   map(mdast, (node) => {
     if (node.type === 'inlineCode' && gatsbyEmbed(node.value)) {
       embed(gatsbyEmbed(node.value), node, EMBED_WHITELIST, logger.warn);

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -84,7 +84,6 @@ class Pipeline {
 
     coerce(this._action);
 
-
     // function chain that was defined last. used for `when` and `unless`
     this._last = null;
     // functions that are executed first

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -81,7 +81,7 @@ class Pipeline {
     this._action.logger = action.logger || nopLogger;
 
     this._action.logger.debug('Creating pipeline');
-    
+
     coerce(this._action);
 
 

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -11,6 +11,7 @@
  */
 const _ = require('lodash/fp');
 const callsites = require('callsites');
+const coerce = require('./utils/coerce-secrets');
 
 const noOp = () => {};
 const nopLogger = {
@@ -80,6 +81,9 @@ class Pipeline {
     this._action.logger = action.logger || nopLogger;
 
     this._action.logger.debug('Creating pipeline');
+    
+    coerce(this._action);
+
 
     // function chain that was defined last. used for `when` and `unless`
     this._last = null;

--- a/src/schemas/secrets.schema.json
+++ b/src/schemas/secrets.schema.json
@@ -25,8 +25,15 @@
   "properties": {
     "REPO_RAW_ROOT": {
       "type": "string",
+      "format": "uri",
       "description": "The Base URL for retrieving raw text files from GitHub",
       "default": "https://raw.githubusercontent.com/"
+    },
+    "REPO_API_ROOT": {
+      "type": "string",
+      "format": "uri",
+      "description": "The base URL for all GitHub API operations",
+      "default": "https://api.github.com/"
     },
     "EMBED_WHITELIST": {
       "type": "string",

--- a/src/schemas/secrets.schema.json
+++ b/src/schemas/secrets.schema.json
@@ -19,7 +19,7 @@
   "description": "Secrets passed into the pipeline such as API Keys or configuration settings.",
   "patternProperties": {
     "[A-Z0-9_]+": {
-      "type": "string"
+      "type": ["boolean", "integer","number","string"]
     }
   },
   "properties": {
@@ -57,6 +57,10 @@
       "type": "string",
       "description": "Value for the `sizes` attribute of generated responsive images",
       "default": "100vw"
+    },
+    "TEST_BOOLEAN": {
+      "type":"boolean",
+      "default": true
     }
   }
 }

--- a/src/schemas/secrets.schema.json
+++ b/src/schemas/secrets.schema.json
@@ -30,27 +30,33 @@
     },
     "EMBED_WHITELIST": {
       "type": "string",
-      "description": "Comma-separated list of allowed hostnames for embeds. Supports `*.example.com` as a subdomain wildcard. Use `*` to allow all embeds (potentially insecure)"
+      "description": "Comma-separated list of allowed hostnames for embeds. Supports `*.example.com` as a subdomain wildcard. Use `*` to allow all embeds (potentially insecure)",
+      "default": "www.youtube.com, spark.adobe.com, unsplash.com/photos"
     },
     "EMBED_SERVICE": {
       "type": "string",
-      "description": "URL of an Embed Service that takes the appended URL and returns an embeddable HTML representation."
+      "description": "URL of an Embed Service that takes the appended URL and returns an embeddable HTML representation.",
+      "default": "https://adobeioruntime.net/api/v1/web/helix/default/embed/"
     },
     "IMAGES_MIN_SIZE": {
-      "type": "string",
-      "description": "Minimum physical width of responsive images to generate"
+      "type": "integer",
+      "description": "Minimum physical width of responsive images to generate",
+      "default": 480
     },
     "IMAGES_MAX_SIZE": {
-      "type": "string",
-      "description": "Maximum physical with of responsive images to generate"
+      "type": "integer",
+      "description": "Maximum physical with of responsive images to generate",
+      "default": 4096
     },
     "IMAGES_SIZE_STEPS": {
-      "type": "string",
-      "description": "Number of intermediary size steps to create per image"
+      "type": "integer",
+      "description": "Number of intermediary size steps to create per image",
+      "default": 4
     },
     "IMAGES_SIZES": {
       "type": "string",
-      "description": "Value for the `sizes` attribute of generated responsive images"
+      "description": "Value for the `sizes` attribute of generated responsive images",
+      "default": "100vw"
     }
   }
 }

--- a/src/utils/coerce-secrets.js
+++ b/src/utils/coerce-secrets.js
@@ -12,13 +12,14 @@
 const ajv = require('./validator');
 
 async function coerce(action) {
-  const validator = await ajv(action.logger, { useDefaults: true, coerceTypes: true });
+  const defaultsetter = await ajv(action.logger, { useDefaults: true, coerceTypes: true });
   if (!action.secrets) {
+    /* eslint-disable no-param-reassign */
     action.secrets = {};
   }
   if (action.secrets) {
-    action.logger.debug('Corecing secrets');
-    validator.validate('https://ns.adobe.com/helix/pipeline/secrets', action.secrets);
+    action.logger.debug('Coercing secrets');
+    defaultsetter.validate('https://ns.adobe.com/helix/pipeline/secrets', action.secrets);
   }
 }
 

--- a/src/utils/coerce-secrets.js
+++ b/src/utils/coerce-secrets.js
@@ -17,10 +17,8 @@ async function coerce(action) {
     /* eslint-disable no-param-reassign */
     action.secrets = {};
   }
-  if (action.secrets) {
-    action.logger.debug('Coercing secrets');
-    defaultsetter.validate('https://ns.adobe.com/helix/pipeline/secrets', action.secrets);
-  }
+  action.logger.debug('Coercing secrets');
+  defaultsetter.validate('https://ns.adobe.com/helix/pipeline/secrets', action.secrets);
 }
 
 module.exports = coerce;

--- a/src/utils/coerce-secrets.js
+++ b/src/utils/coerce-secrets.js
@@ -11,9 +11,13 @@
  */
 const ajv = require('./validator');
 
-async function coerce(_context, action) {
+async function coerce(action) {
   const validator = await ajv(action.logger, { useDefaults: true, coerceTypes: true });
+  if (!action.secrets) {
+    action.secrets = {};
+  }
   if (action.secrets) {
+    action.logger.debug('Corecing secrets');
     validator.validate('https://ns.adobe.com/helix/pipeline/secrets', action.secrets);
   }
 }

--- a/src/utils/coerce-secrets.js
+++ b/src/utils/coerce-secrets.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const ajv = require('./validator');
+
+async function coerce(_context, action) {
+  const validator = await ajv(action.logger, { useDefaults: true, coerceTypes: true });
+  if (action.secrets) {
+    validator.validate('https://ns.adobe.com/helix/pipeline/secrets', action.secrets);
+  }
+}
+
+module.exports = coerce;

--- a/src/utils/embed-handler.js
+++ b/src/utils/embed-handler.js
@@ -13,7 +13,7 @@
  * Handles `embed` MDAST nodes by converting them into `<esi:include>` tags
  * @param {string} EMBED_SERVICE the URL of an embedding service compatible with https://github.com/adobe/helix-embed that returns HTML
  */
-function embed({ EMBED_SERVICE = 'https://adobeioruntime.net/api/v1/web/helix/default/embed/' } = {}) {
+function embed({ EMBED_SERVICE }) {
   return function handler(h, node) {
     const { url } = node;
     const props = {

--- a/src/utils/image-handler.js
+++ b/src/utils/image-handler.js
@@ -36,10 +36,10 @@ function makewidths(options) {
 }
 
 function image({
-  IMAGES_MIN_SIZE = 480,
-  IMAGES_MAX_SIZE = 4096,
-  IMAGES_SIZE_STEPS = 4,
-  IMAGES_SIZES = '100vw',
+  IMAGES_MIN_SIZE,
+  IMAGES_MAX_SIZE,
+  IMAGES_SIZE_STEPS,
+  IMAGES_SIZES,
 } = {}) {
   const widths = {
     from: parseInt(IMAGES_MIN_SIZE, 10),

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -9,34 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-disable no-underscore-dangle */
-const Ajv = require('ajv');
-const fs = require('fs-extra');
-const path = require('path');
-
-let _ajv;
-
-async function ajv(logger) {
-  if (!_ajv) {
-    logger.debug('initializing ajv');
-    const schemadir = path.resolve(__dirname, '..', 'schemas');
-    const validator = new Ajv({ allErrors: true, verbose: true });
-    const sourcefiles = await fs.readdir(schemadir);
-
-    const schemas = sourcefiles
-      .filter(file => file.match(/\.schema\.json$/))
-      .map(schema => path.resolve(schemadir, schema));
-
-    await Promise.all(schemas.map(async (file) => {
-      const schemaData = await fs.readJSON(file);
-      validator.addSchema(schemaData);
-      logger.debug(`- ${schemaData.$id}  (${path.basename(file)})`);
-    }));
-    logger.debug('ajv initialized');
-    _ajv = validator;
-  }
-  return _ajv;
-}
+const ajv = require('./validator');
 
 async function validate(context, action, index) {
   const validator = await ajv(action.logger);

--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-disable no-underscore-dangle */
+const Ajv = require('ajv');
+const fs = require('fs-extra');
+const path = require('path');
+
+let _ajv;
+
+async function ajv(logger, options = {}) {
+  if (!_ajv) {
+    logger.debug('initializing ajv');
+    const schemadir = path.resolve(__dirname, '..', 'schemas');
+    const validator = new Ajv(Object.assign({ allErrors: true, verbose: true }, options));
+    const sourcefiles = await fs.readdir(schemadir);
+
+    const schemas = sourcefiles
+      .filter(file => file.match(/\.schema\.json$/))
+      .map(schema => path.resolve(schemadir, schema));
+
+    await Promise.all(schemas.map(async (file) => {
+      const schemaData = await fs.readJSON(file);
+      validator.addSchema(schemaData);
+      logger.debug(`- ${schemaData.$id}  (${path.basename(file)})`);
+    }));
+    logger.debug('ajv initialized');
+    _ajv = validator;
+  }
+  return _ajv;
+}
+
+module.exports = ajv;

--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -13,12 +13,13 @@
 const Ajv = require('ajv');
 const fs = require('fs-extra');
 const path = require('path');
+const hash = require('object-hash');
 
-let _ajv;
+const _ajv = {};
 
 async function ajv(logger, options = {}) {
-  if (!_ajv) {
-    logger.debug('initializing ajv');
+  if (!_ajv[hash(options)]) {
+    logger.debug(`initializing ajv ${JSON.stringify(options)}`);
     const schemadir = path.resolve(__dirname, '..', 'schemas');
     const validator = new Ajv(Object.assign({ allErrors: true, verbose: true }, options));
     const sourcefiles = await fs.readdir(schemadir);
@@ -33,9 +34,9 @@ async function ajv(logger, options = {}) {
       logger.debug(`- ${schemaData.$id}  (${path.basename(file)})`);
     }));
     logger.debug('ajv initialized');
-    _ajv = validator;
+    _ajv[hash(options)] = validator;
   }
-  return _ajv;
+  return _ajv[hash(options)];
 }
 
 module.exports = ajv;

--- a/test/testCoercer.js
+++ b/test/testCoercer.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+
+const assert = require('assert');
+const winston = require('winston');
+const coerce = require('../src/utils/coerce-secrets');
+
+const logger = winston.createLogger({
+  // tune this for debugging
+  level: 'debug',
+  // and turn this on if you want the output
+  silent: false,
+  format: winston.format.simple(),
+  transports: [new winston.transports.Console()],
+});
+
+describe('Test Coercing Secrets', () => {
+  it('Secrets will be created', async () => {
+    const action = { logger };
+    await coerce(action);
+    assert.ok(action.secrets);
+    assert.equal(typeof action.secrets, 'object');
+  });
+
+  it('Defaults have correct values', async () => {
+    const action = { logger };
+    await coerce(action);
+    assert.ok(action.secrets.REPO_RAW_ROOT);
+    assert.equal(action.secrets.REPO_RAW_ROOT, 'https://raw.githubusercontent.com/');
+  });
+
+  it('Defaults have correct types (number)', async () => {
+    const action = { logger };
+    await coerce(action);
+    assert.ok(action.secrets.IMAGES_MAX_SIZE);
+    assert.equal(action.secrets.IMAGES_MAX_SIZE, 4096);
+    assert.equal(typeof action.secrets.IMAGES_MAX_SIZE, 'number');
+  });
+
+  it('Defaults have correct types (boolean)', async () => {
+    const action = { logger };
+    await coerce(action);
+    assert.equal(typeof action.secrets.TEST_BOOLEAN, 'boolean');
+  });
+
+  it('Secrets have correct types (boolean)', async () => {
+    const action = { logger, secrets: { TEST_BOOLEAN: 'false' } };
+    await coerce(action);
+    assert.equal(action.secrets.TEST_BOOLEAN, false);
+    assert.equal(typeof action.secrets.TEST_BOOLEAN, 'boolean');
+  });
+
+  it('Secrets have correct types (number)', async () => {
+    const action = { logger, secrets: { IMAGES_MAX_SIZE: '4000' } };
+    await coerce(action);
+    assert.equal(action.secrets.IMAGES_MAX_SIZE, 4000);
+    assert.equal(typeof action.secrets.IMAGES_MAX_SIZE, 'number');
+  });
+});

--- a/test/testEmbedHandler.js
+++ b/test/testEmbedHandler.js
@@ -14,6 +14,7 @@ const assert = require('assert');
 const winston = require('winston');
 const embed = require('../src/utils/embed-handler');
 const { pipe } = require('../src/defaults/html.pipe.js');
+const coerce = require('../src/utils/coerce-secrets');
 
 const params = {
   path: '/hello.md',
@@ -74,13 +75,17 @@ const logger = winston.createLogger({
 });
 
 describe('Test Embed Handler', () => {
-  it('Creates ESI', () => {
+  it('Creates ESI', async () => {
     const node = {
       type: 'embed',
       url: 'https://www.example.com/',
     };
 
-    embed()((_, tagname, parameters, children) => {
+    const action = { logger };
+    await coerce(action);
+
+
+    embed(action.secrets)((_, tagname, parameters, children) => {
       assert.equal(parameters.src, 'https://adobeioruntime.net/api/v1/web/helix/default/embed/https://www.example.com/');
       assert.equal(children, undefined);
       assert.equal(tagname, 'esi:include');

--- a/test/testFetchMarkdown.js
+++ b/test/testFetchMarkdown.js
@@ -13,6 +13,7 @@
 const assert = require('assert');
 const winston = require('winston');
 const fetch = require('../src/html/fetch-markdown');
+const coerce = require('../src/utils/coerce-secrets');
 
 const logger = winston.createLogger({
   // tune this for debugging
@@ -190,33 +191,35 @@ describe('Test invalid input', () => {
 
 describe('Test non-existing content', () => {
   it('Getting XDM README (from wrong URL)', async () => {
-    assert.ok((await fetch(
-      {},
-      {
-        request: {
-          params: {
-            repo: 'xdm', ref: 'master', path: 'README.md', owner: 'nobody',
-          },
+    const myaction = {
+      request: {
+        params: {
+          repo: 'xdm', ref: 'master', path: 'README.md', owner: 'nobody',
         },
-        logger,
       },
-    )).error);
+      logger,
+    };
+
+    await coerce(myaction);
+
+    assert.ok((await fetch({}, myaction)).error);
   });
 });
 
 describe('Test requests', () => {
   it('Getting XDM README', async () => {
-    const result = await fetch(
-      {},
-      {
-        request: {
-          params: {
-            repo: 'xdm', ref: 'master', path: 'README.md', owner: 'adobe',
-          },
+    const myaction = {
+      request: {
+        params: {
+          repo: 'xdm', ref: 'master', path: 'README.md', owner: 'adobe',
         },
-        logger,
       },
-    );
+      logger,
+    };
+
+    await coerce(myaction);
+
+    const result = await fetch({}, myaction);
     assert.ok(result.content.body);
   });
 });

--- a/test/testFindEmbeds.js
+++ b/test/testFindEmbeds.js
@@ -14,6 +14,7 @@ const winston = require('winston');
 const parse = require('../src/html/parse-markdown');
 const embeds = require('../src/html/find-embeds');
 const { assertMatch, assertValid } = require('./markdown-utils');
+const coerce = require('../src/utils/coerce-secrets');
 
 const logger = winston.createLogger({
   // tune this for debugging
@@ -24,17 +25,25 @@ const logger = winston.createLogger({
   transports: [new winston.transports.Console()],
 });
 
+const action = {
+  logger,
+};
+
 function mdast(body) {
   const parsed = parse({ content: { body } }, { logger });
-  return embeds(parsed, { logger }).content.mdast;
+  return embeds(parsed, action).content.mdast;
 }
 
 function context(body) {
   const parsed = parse({ content: { body } }, { logger });
-  return embeds(parsed, { logger });
+  return embeds(parsed, action);
 }
 
 describe('Test Embed Detection Processing', () => {
+  before('Coerce defaults', async () => {
+    await coerce(action);
+  });
+
   it('Parses markdown with embeds', () => {
     assertMatch('embeds', mdast);
   });

--- a/test/testOpenwhisk.js
+++ b/test/testOpenwhisk.js
@@ -104,24 +104,22 @@ describe('Testing OpenWhisk adapter', () => {
       payload = p;
     }, pipe, params);
 
-    assert.deepEqual(action, {
-      request: {
-        params: {
-          path: '/test',
-          extension: 'html',
-          selector: 'print.preview',
-          params: 'a=42&b=green',
-        },
-        headers: {
-          Host: 'example.com',
-        },
-        method: 'get',
+    assert.deepEqual(action.request, {
+      params: {
+        path: '/test',
+        extension: 'html',
+        selector: 'print.preview',
+        params: 'a=42&b=green',
       },
-      logger: log,
-      secrets: {
-        SECRET: '1234',
+      headers: {
+        Host: 'example.com',
       },
+      method: 'get',
     });
+
+    assert.deepEqual(action.logger, log);
+
+    assert.deepEqual(action.secrets.SECRET, '1234');
 
     assert.deepEqual(payload, {
       request: {


### PR DESCRIPTION
This is an implementation of #108 

The `coerce` function uses the ability of the `ajv` JSON Schema validator to set defaults that are defined in the schema, but not in the passed object, and to coerce string values into more specific values. As a result, all configuration properties that are documented in the `secrets.schema.json` will be present in the `action` and have the proper type. 